### PR TITLE
Add external cover images

### DIFF
--- a/bl-kernel/abstract/content.class.php
+++ b/bl-kernel/abstract/content.class.php
@@ -170,6 +170,10 @@ class Content {
 			return false;
 		}
 
+		if (preg_match("/^https?:\/\//", $fileName)) {
+			$absolute=false;
+		}
+
 		if($absolute) {
 			return HTML_PATH_UPLOADS.$fileName;
 		}

--- a/bl-kernel/admin/themes/default/init.php
+++ b/bl-kernel/admin/themes/default/init.php
@@ -214,11 +214,37 @@ class HTML {
 
 		$style = '';
 		if(!empty($coverImage)) {
-			$style = 'background-image: url('.HTML_PATH_UPLOADS_THUMBNAILS.$coverImage.')';
+			if (preg_match("/^https?:\/\//", $coverImage)) {
+				$style = 'background-image: url('.$coverImage.')';
+			}
+			else {
+				$style = 'background-image: url('.HTML_PATH_UPLOADS_THUMBNAILS.$coverImage.')';
+			}
 		}
 
 		$html = '<!-- BLUDIT COVER IMAGE -->';
 		$html .= '
+		<div id="bludit-cover-image-modal" class="uk-modal">
+    		<div class="uk-modal-dialog">
+				<form class="uk-form uk-width-medium-1-3">
+					<fieldset>
+						<legend>'.$L->g('External Cover Image').'</legend>
+						<div class="uk-form-row">
+							<input id="external-cover-image-url" type="text" class="uk-width-5-6" placeholder="'.$L->g('Cover Image URL').'" autocomplete="off">
+							<button id="jsExternalCoverImageSave" class="uk-button">'.$L->g('Save').'</button>
+						</div>
+						<legend>'.$L->g('Cover image').'</legend>
+						<div class="uk-form-row">
+							<button id="jsCoverImageUpload" class="uk-button uk-button-primary uk-width-1-1"><i class="uk-icon-upload"></i>&nbsp;'.$L->g('Upload image').'</button>
+						</div>						
+					</fieldset>
+				</form>
+				<div class="uk-modal-footer">
+					<a href="" class="uk-modal-close">'.$L->g('Click here to cancel').'</a>
+				</div>
+    		</div>
+		</div>
+
 		<div id="bludit-cover-image">
 		<div id="cover-image-thumbnail" class="uk-form-file uk-placeholder uk-text-center" style="'.$style.'">
 

--- a/bl-kernel/js/bludit-cover-image.js
+++ b/bl-kernel/js/bludit-cover-image.js
@@ -4,7 +4,16 @@ var coverImage = new function() {
 
 	this.set = function(filename) {
 
-		var imageSrc = HTML_PATH_UPLOADS_THUMBNAILS + filename;
+		var externalCoverImage = true;
+		var imageSrc = "";
+
+		var expression = /^https?:\/\//gi;
+		var regex = new RegExp(expression);		
+		if (!filename.match(regex)) {
+			externalCoverImage = false;
+			imageSrc += HTML_PATH_UPLOADS_THUMBNAILS;
+		}
+		imageSrc += filename;
 
 		// Cover image background
 		$("#cover-image-thumbnail").attr("style", "background-image: url("+imageSrc+")");
@@ -19,7 +28,9 @@ var coverImage = new function() {
 		$("#cover-image-upload").hide();
 
 		// Hide box "There are no images"
-		$(".empty-images").hide();
+		if (!externalCoverImage) {
+			$(".empty-images").hide();
+		}
 
 	}
 
@@ -43,12 +54,55 @@ var coverImage = new function() {
 
 $(document).ready(function() {
 
+	var coverImageTypeSelected = false;
+	var modal = UIkit.modal("#bludit-cover-image-modal");
+	$("#bludit-cover-image").on("click", function(e){
+		if (coverImageTypeSelected) {
+			coverImageTypeSelected = !coverImageTypeSelected;
+			return;
+		}
+		if ( modal.isActive() ) {
+    			modal.hide();
+			} else {
+				$("#external-cover-image-url").val("");
+    			modal.show();
+				$("#external-cover-image-url").focus();
+			}	
+			e.stopPropagation();
+			e.preventDefault();	
+		});
+	// Stores the external cover image url		
+	$("#jsExternalCoverImageSave").on("click", function(e){
+		e.stopPropagation();
+		e.preventDefault();		
+		modal.hide();
+		if ($("#external-cover-image-url").val().length > 0) {
+			var expression = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,4}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)\/\S+\.(jpg|jpeg|gif|png)/gi;
+			var regex = new RegExp(expression);
+			if ($("#external-cover-image-url").val().match(regex)) {
+				coverImage.set($("#external-cover-image-url").val().toLowerCase());
+			}
+			else {
+				alert("<?php echo $L->g('error').'. '.$L->g('Invalid cover image URL')?>.");
+			}
+		}
+	});
+	// Proceed with cover image upload
+	$("#jsCoverImageUpload").on("click", function(e){
+		e.stopPropagation();
+		e.preventDefault();				
+		modal.hide();
+		coverImageTypeSelected = true;
+		$("#cover-image-file-select").trigger("click");
+	});	
+
 	// Click on delete cover image.
-	$("#cover-image-delete").on("click", function() {
+	$("#cover-image-delete").on("click", function(e) {
 
 		// Remove the cover image.
 		coverImage.remove();
-
+		e.stopPropagation();
+		
 	});
 
 	var settings =

--- a/bl-languages/en_US.json
+++ b/bl-languages/en_US.json
@@ -249,5 +249,8 @@
 	"add-a-new-page": "Add a new page",
 	"add-a-new-post": "Add a new post",
 
-	"save-as-draft": "Save as draft"
+	"save-as-draft": "Save as draft",
+	"invalid-cover-image-url": "Invalid cover image URL",
+	"external-cover-image": "External Cover Image",
+	"cover-image-url": "Cover Image URL"
 }

--- a/bl-languages/pt_BR.json
+++ b/bl-languages/pt_BR.json
@@ -234,5 +234,8 @@
 	"сurrent-status" : "Estado atual",
 	"disable-the-user" : "Desabilitar usuário",
 	"add-a-new-page": "Criar nova página",
-	"add-a-new-post": "Criar nova entrada"
+	"add-a-new-post": "Criar nova entrada",
+	"invalid-cover-image-url": "URL inválida para a imagem de capa",
+	"external-cover-image": "Imagem de capa externa",
+	"cover-image-url": "URL da imagem de capa"	
 }


### PR DESCRIPTION
Allows using an image hosted on a different domain as cover image.

_I use a CDN to store my images, thus I made these changes so I can use it as the source of Bludit's cover images._
