### PR TITLE
Category descriptions

### DIFF
--- a/bl-kernel/abstract/dblist.class.php
+++ b/bl-kernel/abstract/dblist.class.php
@@ -102,12 +102,15 @@ class dbList extends dbJSON
 		return $this->save();
 	}
 
-	public function edit($oldKey, $newName)
+	public function edit($oldKey, $newName, $properties)
 	{
 		$newKey = $this->generateKey($newName);
 
 		$this->db[$newKey]['name'] = Sanitize::html($newName);
 		$this->db[$newKey]['list'] = $this->db[$oldKey]['list'];
+
+		foreach ($properties as $propertyKey => $propertyValue)
+			$this->db[$newKey][$propertyKey] = Sanitize::html($propertyValue);
 
 		// Remove the old key
 		if( $oldKey != $newKey ) {
@@ -129,8 +132,14 @@ class dbList extends dbJSON
 	// Returns the name associated to the key, FALSE if the key doesn't exist
 	public function getName($key)
 	{
-		if( isset($this->db[$key]) ) {
-			return $this->db[$key]['name'];
+		return $this->getProperty($key, 'name');
+	}
+
+	// Returns a property associated to the key, FALSE if the key doesn't exist
+	public function getProperty($key, $property)
+	{
+		if( isset($this->db[$key]) && isset($this->db[$key][$property])) {
+			return $this->db[$key][$property];
 		}
 
 		return false;

--- a/bl-kernel/admin/controllers/edit-category.php
+++ b/bl-kernel/admin/controllers/edit-category.php
@@ -26,7 +26,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 		deleteCategory($_POST['categoryKey']);
 	}
 	elseif (isset($_POST['edit'])) {
-		editCategory($_POST['categoryKey'], $_POST['category']);
+		editCategory($_POST['categoryKey'], $_POST['category'], $_POST['categoryDescription']);
 	}
 
 	Redirect::page('categories');

--- a/bl-kernel/admin/views/edit-category.php
+++ b/bl-kernel/admin/views/edit-category.php
@@ -21,6 +21,13 @@ HTML::formOpen(array('class'=>'uk-form-horizontal'));
 		'class'=>'uk-width-1-2 uk-form-medium'
 	));
 
+	HTML::formTextArea(array(
+		'name'=>'categoryDescription',
+		'label'=>$L->g('Description'),
+		'value'=>$dbCategories->getProperty($categoryKey, 'description'),
+		'class'=>'uk-width-1-2 uk-form-medium'
+	));
+
 	echo '<div class="uk-form-row">
 		<div class="uk-form-controls">
 		<button type="submit" name="edit" class="uk-button uk-button-primary">'.$L->g('Save').'</button>

--- a/bl-kernel/functions.php
+++ b/bl-kernel/functions.php
@@ -662,7 +662,7 @@ function createCategory($category) {
 	return false;
 }
 
-function editCategory($oldCategoryKey, $newCategory) {
+function editCategory($oldCategoryKey, $newCategory, $newDescription) {
 	global $Language;
 	global $dbPages;
 	global $dbCategories;
@@ -673,7 +673,8 @@ function editCategory($oldCategoryKey, $newCategory) {
 		return false;
 	}
 
-	if( $dbCategories->edit($oldCategoryKey, $newCategory) == false ) {
+	$properties = array('description' => $newDescription);
+	if( $dbCategories->edit($oldCategoryKey, $newCategory, $properties) == false ) {
 		Alert::set($Language->g('Already exist a category'));
 		return false;
 	}

--- a/bl-kernel/page.class.php
+++ b/bl-kernel/page.class.php
@@ -222,6 +222,13 @@ class Page {
 		return $this->getValue('category');
 	}
 
+	// Returns the category description
+	public function categoryDescription()
+	{
+		global $dbCategories;
+		return $dbCategories->getProperty($this->categoryKey(), 'description');
+	}
+
 	// Returns the field from the array
 	// categoryMap = array( 'name'=>'', 'list'=>array() )
 	public function categoryMap($field)


### PR DESCRIPTION
Add descriptions to categories via the manage categories admin page, and access them in themes via the `$Page` global object. PR changes consist of:

- Change `dbList::edit()` to allow any property via an array
- Add method `dbList::getProperty()` to access saved properties, and edit `dbList::getName()` to use it
- Change `editCategory()` function to include a description parameter
- Add input field to edit category view and controller scripts
- Add method `Page::categoryDescription()` for access in themes