### PR TITLE
bugfix label text for admin interface

### DIFF
--- a/bl-kernel/admin/themes/booty/init.php
+++ b/bl-kernel/admin/themes/booty/init.php
@@ -262,7 +262,7 @@ EOF;
 
 		$label = '';
 		if (isset($args['label'])) {
-			$label = '<label for="$id" class="col-sm-2 col-form-label">$label</label>';
+			$label = '<label for="'.$id.'" class="col-sm-2 col-form-label">'.$args['label'].'</label>';
 		}
 
 		$class = 'form-control';


### PR DESCRIPTION
On formInputText it didn't show the label name, because of missing quotes and wrong var name