### PR TITLE
Add pathFile Sanitization on Plugins

### DIFF
--- a/bl-kernel/abstract/plugin.class.php
+++ b/bl-kernel/abstract/plugin.class.php
@@ -55,13 +55,16 @@ class Plugin {
 
 		// --- Metadata ---
 		$this->filenameMetadata = PATH_PLUGINS.$this->directoryName().DS.'metadata.json';
-		$metadataString = file_get_contents($this->filenameMetadata);
-		$this->metadata = json_decode($metadataString, true);
 
-		// If the plugin is installed then get the database
-		if ($this->installed()) {
-			$Tmp = new dbJSON($this->filenameDb);
-			$this->db = $Tmp->db;
+		if( Sanitize::pathFile($this->filenameMetadata) ) {
+			$metadataString = file_get_contents($this->filenameMetadata);
+			$this->metadata = json_decode($metadataString, true);
+
+			// If the plugin is installed then get the database
+			if ($this->installed()) {
+				$Tmp = new dbJSON($this->filenameDb);
+				$this->db = $Tmp->db;
+			}
 		}
 	}
 

--- a/bl-kernel/boot/rules/60.plugins.php
+++ b/bl-kernel/boot/rules/60.plugins.php
@@ -78,6 +78,9 @@ function buildPlugins()
 		$languageFilename = PATH_PLUGINS.$Plugin->directoryName().DS.'languages'.DS.$site->language().'.json';
 		if( !Sanitize::pathFile($languageFilename) ) {
 			$languageFilename = PATH_PLUGINS.$Plugin->directoryName().DS.'languages'.DS.DEFAULT_LANGUAGE_FILE;
+			if( !Sanitize::pathFile($languageFilename) ) {
+				continue;
+			}
 		}
 
 		$database = file_get_contents($languageFilename);


### PR DESCRIPTION
Just adds a `Sanitize::pathFile` check on the Plugin constructor (`plugin.class.php`) as well as on the `60.plugins.php` boot file to prevent an error, if an empty (or non-plugin) folder is within the `bl-plugins` directory.