### PR TITLE
allow to place metadata all over the file

### DIFF
--- a/bl-plugins/remote-content/plugin.php
+++ b/bl-plugins/remote-content/plugin.php
@@ -183,7 +183,7 @@ class pluginRemoteContent extends Plugin {
 
 				unset($lines[$key]);
 			} else {
-				break;
+				continue;
 			}
 		}
 


### PR DESCRIPTION
breaking the foreach loop for any line that doesn't start with '<!--' is unnecessary. Using 'continue' allows the metadata to be placed anywhere in the file.

I think this benefits for all authors. This way they can put the meta data at the end of the file, group them etc.