### PR TITLE
Use comma for imploding robots meta tag

### DIFF
--- a/bl-plugins/robots/plugin.php
+++ b/bl-plugins/robots/plugin.php
@@ -45,7 +45,7 @@ class pluginRobots extends Plugin {
 			}
 
 			if (!empty($robots)) {
-				$robots = implode(' ', $robots);
+				$robots = implode(',', $robots);
 				$html .= '<meta name="robots" content="'.$robots.'">'.PHP_EOL;
 			}
 		}


### PR DESCRIPTION
According to https://developers.google.com/search/reference/robots_meta_tag, http://www.robotstxt.org/meta.html and https://www.webmasterworld.com/forum93/669.htm using only a space between the values probably isn't the proper syntax and could ignore all values (perhaps that explains why Google ignored my `noindex nofollow`).