### PR TITLE
add request: allow plugins to create own hooks

### DIFF
--- a/bl-kernel/boot/rules/60.plugins.php
+++ b/bl-kernel/boot/rules/60.plugins.php
@@ -99,25 +99,23 @@ function buildPlugins()
 
 		// If the plugin is installed insert on the hooks
 		if ($Plugin->installed()) {
+            
+			// If the plugin contains the function "registerHooks" returning a String array, 
+		    	//it will called and if those hooks are not existing they will added
+		    	if(method_exists($Plugin, "registerHooks")) {
+				foreach (call_user_func("{$Plugin->className()}::registerHooks") as $customEvent) {
+			    		if(!isset($plugins[$customEvent])){
+						$plugins[$customEvent] = array();
+						$pluginsEvents[$customEvent] = array();
+			    		}
+				}
+		    	}
+            
 			foreach ($pluginsEvents as $event=>$value) {
 				if (method_exists($Plugin, $event)) {
 					array_push($plugins[$event], $Plugin);
 				}
 			}
-			
-			/* THIS PART IS FOR CUSTOM HOOKS */
-			if(method_exists($Plugin, "registerHooks"))
-			{
-				foreach (call_user_func("{$Plugin->className()}::registerHooks") as $customEvent)
-				{
-					if (method_exists($Plugin, $customEvent)) 
-					{
-						$plugins[$customEvent] = array();
-						array_push($plugins[$customEvent], $Plugin);
-					}
-				}
-			}
-			/* THIS PART IS FOR CUSTOM HOOKS */
 		}
 
 		uasort($plugins['siteSidebar'], function ($a, $b) {

--- a/bl-kernel/boot/rules/60.plugins.php
+++ b/bl-kernel/boot/rules/60.plugins.php
@@ -104,6 +104,20 @@ function buildPlugins()
 					array_push($plugins[$event], $Plugin);
 				}
 			}
+			
+			/* THIS PART IS FOR CUSTOM HOOKS */
+			if(method_exists($Plugin, "registerHooks"))
+			{
+				foreach (call_user_func("{$Plugin->className()}::registerHooks") as $customEvent)
+				{
+					if (method_exists($Plugin, $customEvent)) 
+					{
+						$plugins[$customEvent] = array();
+						array_push($plugins[$customEvent], $Plugin);
+					}
+				}
+			}
+			/* THIS PART IS FOR CUSTOM HOOKS */
 		}
 
 		uasort($plugins['siteSidebar'], function ($a, $b) {


### PR DESCRIPTION
With custom hooks, you can place your plugin's data anywhere you want. For example, you have a footer and you want to have links in your footer. There is a link plugin that displays links in the SiteBar with "<? Php Theme :: plugins ('siteSidebar');?>". If you put this code in your footer, all plugins that use "siteSidebar" will be placed in your footer. With my pull request you can now create your own hooks and it can be guaranteed that only a single plugin places its data there but only if its the only plugin implementing your custom hook.

How to create custom hooks:
in your plugin.php you have to place a  public function "registerHooks" returning an array of String.

```
 public function registerHooks()
 {
    return array(
        "akLinks",
        "akBusinessHours"
    );
}
```
