### PR TITLE
Add "requests" Hook

### DIFF
--- a/bl-kernel/boot/rules/60.plugins.php
+++ b/bl-kernel/boot/rules/60.plugins.php
@@ -103,6 +103,10 @@ function buildPlugins()
 				if (method_exists($Plugin, $event)) {
 					array_push($plugins[$event], $Plugin);
 				}
+
+				if (method_exists($Plugin, "requests")) {
+					call_user_func(array($Plugin, "requests"));
+				}
 			}
 		}
 


### PR DESCRIPTION
Hellow,

it would be really helpful, if a final hook is called after the plugin is completely initialized and the language files are completely loaded. So it would be way easier to hook methods, which handles POST and GET requests as early as possible (Therefore i named the hook "requests" :D). 

The `beforeAdminLoad` hook isn't capable for a few purposes.

### Current Solution
I'm currently using a "dirty" solution on my plugins, which overwrites the `installed()` method, waits until the second call (which is made within the `60.plugins.php` boot file) to hook my _POST and _GET requests. The `init` method is called to early and the language strings aren't loaded until the `installed` method was called for the second time.

[The current solution I'm using on my paw.designer Plugin](https://github.com/pytesNET/paw.designer/blob/master/plugin.php#L233)

Would be a great help for developing.

Thanks.

Sincerely,
Sam.