### PR TITLE
Enable adminSidebar() also for Editors

### DIFF
--- a/bl-kernel/admin/themes/booty/html/sidebar.php
+++ b/bl-kernel/admin/themes/booty/html/sidebar.php
@@ -57,7 +57,11 @@
 	<li class="nav-item">
 		<a class="nav-link" href="<?php echo HTML_PATH_ADMIN_ROOT.'about' ?>"><?php $L->p('About') ?></a>
 	</li>
+	
+	<?php endif; ?>
 
+	<?php if (checkRole(array('admin', 'editor'),false)): ?>
+	
 		<?php
 			if (!empty($plugins['adminSidebar'])) {
 				echo '<li class="nav-item"><hr></li>';
@@ -68,6 +72,7 @@
 				}
 			}
 		?>
+	
 	<?php endif; ?>
 
 	<li class="nav-item mt-5">


### PR DESCRIPTION
Hellow,

as mentioned in [this Forum Post](https://forum.bludit.org/viewtopic.php?f=20&t=1426) (written in German), it would be really awesome to "show" custom admin sidebar links for editors too. So plugins, which handles any content related stuff, would be also available for non-adminstrators.

Thanks.

Sincerely,
Sam.