### PR TITLE
Add category and tag index capabilities

### DIFF
--- a/bl-kernel/url.class.php
+++ b/bl-kernel/url.class.php
@@ -71,11 +71,11 @@ class Url
 					$this->setWhereAmI('home');
 				} elseif (!empty($this->slug) && ($filterURI=='/')) {
 					$this->setWhereAmI('page');
-				} elseif (empty($this->slug) && ($filterName==TAG_URI_FILTER)) {
-					$this->slug = TAG_URI_FILTER;
+				} elseif (empty($this->slug) && ($filterName==$this->filters('tag'))) {
+					$this->slug = $this->filters('tag');
 					$this->setWhereAmI('page');
-				} elseif (empty($this->slug) && ($filterName==CATEGORY_URI_FILTER)) {
-					$this->slug = CATEGORY_URI_FILTER;
+				} elseif (empty($this->slug) && ($filterName==$this->filters('category'))) {
+					$this->slug = $this->filters('category');
 					$this->setWhereAmI('page');
 				} elseif ($filterName=='admin') {
 					$this->slug = ltrim($this->slug, '/');

--- a/bl-kernel/url.class.php
+++ b/bl-kernel/url.class.php
@@ -56,12 +56,6 @@ class Url
 
 			$subString = mb_substr($this->uri, 0, $filterFullLenght, CHARSET);
 
-			// Check coincidence without the last slash at the end, this case is notfound
-			if ($subString==$filterURIwoSlash) {
-				$this->setNotFound();
-				return false;
-			}
-
 			// Check coincidence with complete filterURI
 			if ($subString==$filterFull) {
 				$this->slug = mb_substr($this->uri, $filterFullLenght);
@@ -76,6 +70,9 @@ class Url
 				} elseif (empty($this->slug) && ($filterURI=='/')) {
 					$this->setWhereAmI('home');
 				} elseif (!empty($this->slug) && ($filterURI=='/')) {
+					$this->setWhereAmI('page');
+				} elseif (empty($this->slug) && ($filterName=='tag')) {
+          $this->slug = 'tag';
 					$this->setWhereAmI('page');
 				} elseif ($filterName=='admin') {
 					$this->slug = ltrim($this->slug, '/');

--- a/bl-kernel/url.class.php
+++ b/bl-kernel/url.class.php
@@ -74,6 +74,9 @@ class Url
 				} elseif (empty($this->slug) && ($filterName==TAG_URI_FILTER)) {
 					$this->slug = TAG_URI_FILTER;
 					$this->setWhereAmI('page');
+				} elseif (empty($this->slug) && ($filterName==CATEGORY_URI_FILTER)) {
+					$this->slug = CATEGORY_URI_FILTER;
+					$this->setWhereAmI('page');
 				} elseif ($filterName=='admin') {
 					$this->slug = ltrim($this->slug, '/');
 				}

--- a/bl-kernel/url.class.php
+++ b/bl-kernel/url.class.php
@@ -71,10 +71,10 @@ class Url
 					$this->setWhereAmI('home');
 				} elseif (!empty($this->slug) && ($filterURI=='/')) {
 					$this->setWhereAmI('page');
-				} elseif (empty($this->slug) && ($filterName==$this->filters('tag'))) {
+				} elseif (empty($this->slug) && ($filterName=='tag')) {
 					$this->slug = $this->filters('tag');
 					$this->setWhereAmI('page');
-				} elseif (empty($this->slug) && ($filterName==$this->filters('category'))) {
+				} elseif (empty($this->slug) && ($filterName=='category')) {
 					$this->slug = $this->filters('category');
 					$this->setWhereAmI('page');
 				} elseif ($filterName=='admin') {

--- a/bl-kernel/url.class.php
+++ b/bl-kernel/url.class.php
@@ -71,8 +71,8 @@ class Url
 					$this->setWhereAmI('home');
 				} elseif (!empty($this->slug) && ($filterURI=='/')) {
 					$this->setWhereAmI('page');
-				} elseif (empty($this->slug) && ($filterName=='tag')) {
-          $this->slug = 'tag';
+				} elseif (empty($this->slug) && ($filterName==TAG_URI_FILTER)) {
+					$this->slug = TAG_URI_FILTER;
 					$this->setWhereAmI('page');
 				} elseif ($filterName=='admin') {
 					$this->slug = ltrim($this->slug, '/');


### PR DESCRIPTION
Fixes #1076.

## Contents of this PR

1. This removes the [early 404 exit](https://github.com/bludit/bludit/blob/master/bl-kernel/url.class.php#L59) for `/tag` or `/category`, i.e. the filter prefix without a trailing slash. 
    - [ ] @dignajar  Are there other filters where this is desirable? If so, undo the change and add a condition that checks for `CATEGORY_URI_FILTER` and `TAG_URI_FILTER` only.
2. When the remaining aka "filtered" URL slug is empty _and_ the `filterName` is `CATEGORY_URI_FILTER` and `TAG_URI_FILTER`, Bludit now falls back to page display. This way, users can add static `/tag` and `/category` pages to their sites with an index.

Previously, users were allowed to create pages with URL slugs that equal `CATEGORY_URI_FILTER` or `TAG_URI_FILTER`, but these pages were never reachable because Bludit exited early. With this change, Bludit at least tries to access a corresponding page.

## Example: automatic index

To generate an index of all tags automatically, the page corresponding to `/tag` can specify a special theme template, e.g. `all_tags`. The theme template `all_tags.php` can then fetch a list of tags and display them as a list:

`my_custom_theme/php/all_tags.php`:

```php
  <h1><?= $page->title(); ?></h1>

  <?= $page->content(); ?>

  <ul>
  <?php foreach ($tags->keys() as $tag): ?>
    <li class="tag"><a class="tag_link" href="<?= DOMAIN_TAGS.$tag ?>"><?= $tag ?></a>
  <?php endforeach ?>
  </ul>
</section>
```

If the theme does not support this, users can still add a  manual list of links to the page content.
