### PR TITLE
Remove use of headers that can be used to bypass anti-brute force controls

### DIFF
--- a/bl-kernel/security.class.php
+++ b/bl-kernel/security.class.php
@@ -107,13 +107,6 @@ class Security extends dbJSON
 
 	public function getUserIp()
 	{
-		if (getenv('HTTP_X_FORWARDED_FOR')) {
-			$ip = getenv('HTTP_X_FORWARDED_FOR');
-		} elseif (getenv('HTTP_CLIENT_IP')) {
-			$ip = getenv('HTTP_CLIENT_IP');
-		} else {
-			$ip = getenv('REMOTE_ADDR');
-		}
-		return $ip;
+		return getenv('REMOTE_ADDR');
 	}
 }


### PR DESCRIPTION
In `bl-kernel/security.class.php`, there is some code that will check the number of incorrect login attempts made by a host. If the host makes 10 incorrect attempts, they will be temporarily blocked in order to mitigate brute force attempts.

Due to the way the IP address detection is handled, the mechanism can be completely bypassed. The `X-Forwarded-For` and `Client-IP` headers are both checked for (presumably in order to try and detect the IP address of people behind proxies). Unfortunately, both of these headers are easily spoofed, and for an attacker that is running an automated brute force, this will make the process significantly easier than say switching between VPNs as each address gets banned.

I have included a proof of concept demo below in which you can see a total of 51 requests being made (far exceeding the limit) and successfully recovering my admin password:

[![asciicast](https://asciinema.org/a/272661.svg)](https://asciinema.org/a/272661)

This is done by using unique `X-Forwarded-For` addresses for each request. As there is no validation, simply using the value of the password being attempted will work, allowing for a brute force without the risk of locking anyone out at all, as can be seen when inspecting the log file after the brute force has been completed.

Although with this change, it means users who are using a shared IP address via a proxy may be blocked if another person using the same IP is trying to brute force the login page, it will make an automated attack significantly more difficult for an attacker and require that they have multiple IP addresses that they can send traffic from.
