### PR TITLE
Switched the Paginator buttons

### DIFF
--- a/bl-kernel/helpers/paginator.class.php
+++ b/bl-kernel/helpers/paginator.class.php
@@ -109,14 +109,14 @@ class Paginator {
 		$html  = '<div id="paginator">';
 		$html .= '<ul>';
 
-		if(self::get('showNext'))
+		if(self::get('showPrev'))
 		{
 			if($textPrevPage===false) {
 				$textPrevPage = '« '.$L->g('Previous page');
 			}
 
 			$html .= '<li class="left">';
-			$html .= '<a href="'.self::nextPageUrl().'">'.$textPrevPage.'</a>';
+			$html .= '<a href="'.self::previousPrevUrl().'">'.$textPrevPage.'</a>';
 			$html .= '</li>';
 		}
 
@@ -124,14 +124,14 @@ class Paginator {
 			$html .= '<li class="list">'.(self::get('currentPage')+1).' / '.(self::get('numberOfPages')+1).'</li>';
 		}
 
-		if(self::get('showPrev'))
+		if(self::get('showNext'))
 		{
 			if($textNextPage===false) {
 				$textNextPage = $L->g('Next page').' »';
 			}
 
 			$html .= '<li class="right">';
-			$html .= '<a href="'.self::previousPageUrl().'">'.$textNextPage.'</a>';
+			$html .= '<a href="'.self::nextPageUrl().'">'.$textNextPage.'</a>';
 			$html .= '</li>';
 		}
 


### PR DESCRIPTION
The paginator buttons were switched because the navigation was uncommon and lead to confusion the way it currently works.

Maybe this could be changed with using a config parameter as some people might find it better if the navigation is working the other way.