### PR TITLE
Update \bludit\bl-plugins\version\js\version.js

### DIFF
--- a/bl-plugins/version/js/version.js
+++ b/bl-plugins/version/js/version.js
@@ -10,7 +10,7 @@ function getLatestVersion() {
 		success: function(json) {
 			// Constant BLUDIT_BUILD is defined on variables.js
 			if (json.stable.build > BLUDIT_BUILD) {
-				$("#current-version").hide();
+				//$("#current-version").hide(); //Uncomment if you want to hide the current version when a new version is available, but this is unhelpful.
 				$("#new-version").show();
 			}
 		},


### PR DESCRIPTION
Hi @dignajar , would you please consider this slight alteration.
Prevent the Version plugin from hiding the current version on the screen when a new version is available as this is not helpful.
The image below shows the alteration prior to an upgrade, showing that a new version is available and afterwards when the current version equals the latest bludit version.
![image](https://user-images.githubusercontent.com/37149377/68077644-2d2cc380-fdbf-11e9-89e0-3706550ab2fc.png)
