### PR TITLE
Allow passing in attributes for Theme js files

### DIFF
--- a/bl-kernel/helpers/theme.class.php
+++ b/bl-kernel/helpers/theme.class.php
@@ -206,7 +206,7 @@ class Theme {
 		return $links;
 	}
 
-	public static function javascript($files, $base=DOMAIN_THEME)
+	public static function javascript($files, $base=DOMAIN_THEME, $attributes="async")
 	{
 		if( !is_array($files) ) {
 			$files = array($files);
@@ -214,15 +214,15 @@ class Theme {
 
 		$scripts = '';
 		foreach($files as $file) {
-			$scripts .= '<script async src="'.$base.$file.'?version='.BLUDIT_VERSION.'"></script>'.PHP_EOL;
+			$scripts .= '<script '.$attributes.' src="'.$base.$file.'?version='.BLUDIT_VERSION.'"></script>'.PHP_EOL;
 		}
 
 		return $scripts;
 	}
 
-	public static function js($files, $base=DOMAIN_THEME)
+	public static function js($files, $base=DOMAIN_THEME, $attributes="async")
 	{
-		return self::javascript($files, $base);
+		return self::javascript($files, $base, $attributes);
 	}
 
 	public static function plugins($type)


### PR DESCRIPTION
This is a follow up to a previous PR. The `async` attribute can cause issues with some js files. For instance I added the [lozad.js](https://github.com/ApoorvSaxena/lozad.js) for lazy loading and included it via my theme. However, with the current automatic inclusion of `async` things didn't work. 

So this update allows Theme developers to prevent the `async` attribute by passing in `null`.

Example: 
```
<?php echo Theme::javascript('js/lozad.min.js', DOMAIN_THEME, null); ?>
```

If the Theme developer doesn't include `null` the default will be to use `async`.