### PR TITLE
Prepend sticky pages to getList

### DIFF
--- a/bl-kernel/pages.class.php
+++ b/bl-kernel/pages.class.php
@@ -541,7 +541,7 @@ class Pages extends dbJSON {
 			} elseif ($static && $fields['type']=='static') {
 				array_push($list, $key);
 			} elseif ($sticky && $fields['type']=='sticky') {
-				array_push($list, $key);
+				array_unshift($list, $key);
 			} elseif ($draft && $fields['type']=='draft') {
 				array_push($list, $key);
 			} elseif ($scheduled && $fields['type']=='scheduled') {


### PR DESCRIPTION
As there is no way to comfortably sort pages by sticky first, we can, as an interim solution unshift sticky pages instead of pushing them.