### PR TITLE
[BUGFIX] ZIP Paths may starts with an (back-) slash

### DIFF
--- a/bl-kernel/helpers/filesystem.class.php
+++ b/bl-kernel/helpers/filesystem.class.php
@@ -175,9 +175,9 @@ class Filesystem {
 			foreach ($files as $file) {
 				$file = realpath($file);
 				if (is_dir($file)) {
-					$zip->addEmptyDir(str_replace($source, '', $file));
+					$zip->addEmptyDir(ltrim(str_replace($source, '', $file), "/\\"));
 				} elseif (is_file($file)) {
-					$zip->addFromString(str_replace($source, '', $file), file_get_contents($file));
+					$zip->addFromString(ltrim(str_replace($source, '', $file), "/\\"), file_get_contents($file));
 				}
 			}
 		} elseif (is_file($source)) {


### PR DESCRIPTION
Hellow,

the Backup plugin doesn't work properly as described on this [forum post](https://forum.bludit.org/viewtopic.php?f=20&p=8153#p8153) (written in German).

The issue is mainly located on the filesystem helper file starting at line 177

```php
if (is_dir($file)) {
    $zip->addEmptyDir(str_replace($source, '', $file));
} elseif (is_file($file)) {
    $zip->addFromString(str_replace($source, '', $file), file_get_contents($file));
}
```

The internal ZIP Path (set as first parameter on both functions) starts with a (back-) slash, if `$source` doesn't end with the respective directory separator. 

This leads to an "invalid" ZIP path structure (okay, it is not invalid but everything gets written in an invisible unnamed directory). That's also the reason why the backup plugin doesn't work, because the path used for it doesn't end with a directory separator.

Sincerely,
Sam.