### PR TITLE
Add custom admin pages

### DIFF
--- a/bl-kernel/admin/themes/booty/index.php
+++ b/bl-kernel/admin/themes/booty/index.php
@@ -80,6 +80,8 @@
 		<?php
 			if (Sanitize::pathFile(PATH_ADMIN_VIEWS, $layout['view'].'.php')) {
 				include(PATH_ADMIN_VIEWS.$layout['view'].'.php');
+			} else if (isset($plugin) && method_exists($plugin, "adminView")) {
+				echo $plugin->adminView();
 			} else {
 				echo '<h1 class="text-center">'.$L->g('Page not found').'</h1>';
 				echo '<h2 class="text-center">'.$L->g('Choose a page from the sidebar.').'</h2>';

--- a/bl-kernel/admin/themes/booty/index.php
+++ b/bl-kernel/admin/themes/booty/index.php
@@ -80,8 +80,8 @@
 		<?php
 			if (Sanitize::pathFile(PATH_ADMIN_VIEWS, $layout['view'].'.php')) {
 				include(PATH_ADMIN_VIEWS.$layout['view'].'.php');
-			} else if (isset($plugin) && method_exists($plugin, "adminView")) {
-				echo $plugin->adminView();
+			} else if (!empty($layout['plugin']) && method_exists($layout['plugin'], 'adminView')) {
+				echo $layout['plugin']->adminView();
 			} else {
 				echo '<h1 class="text-center">'.$L->g('Page not found').'</h1>';
 				echo '<h2 class="text-center">'.$L->g('Choose a page from the sidebar.').'</h2>';

--- a/bl-kernel/boot/admin.php
+++ b/bl-kernel/boot/admin.php
@@ -69,8 +69,8 @@ else
 	}
 
 	// Define variables
-	$ADMIN_CONTROLLER	= $layout['controller'];
-	$ADMIN_VIEW			= $layout['view'];
+	$ADMIN_CONTROLLER 	= $layout['controller'];
+	$ADMIN_VIEW 		= $layout['view'];
 
 	// Load plugins before the admin area will be load.
 	Theme::plugins('beforeAdminLoad');

--- a/bl-kernel/boot/admin.php
+++ b/bl-kernel/boot/admin.php
@@ -63,8 +63,8 @@ else
 	}
 
 	// Define variables
-	$ADMIN_CONTROLLER	= $layout['controller'];
-	$ADMIN_VIEW			= $layout['view'];
+	$ADMIN_CONTROLLER 	= $layout['controller'];
+	$ADMIN_VIEW 		= $layout['view'];
 
 	// Load plugins before the admin area will be load.
 	Theme::plugins('beforeAdminLoad');

--- a/bl-kernel/boot/admin.php
+++ b/bl-kernel/boot/admin.php
@@ -63,8 +63,8 @@ else
 	}
 
 	// Define variables
-	$ADMIN_CONTROLLER 	= $layout['controller'];
-	$ADMIN_VIEW 		= $layout['view'];
+	$ADMIN_CONTROLLER	= $layout['controller'];
+	$ADMIN_VIEW			= $layout['view'];
 
 	// Load plugins before the admin area will be load.
 	Theme::plugins('beforeAdminLoad');
@@ -77,6 +77,10 @@ else
 	// Load controller.
 	if (Sanitize::pathFile(PATH_ADMIN_CONTROLLERS, $layout['controller'].'.php')) {
 		include(PATH_ADMIN_CONTROLLERS.$layout['controller'].'.php');
+	} else if (($plugin = getPlugin($layout['controller'])) !== false) {
+		if (method_exists($plugin, "adminController") && method_exists($plugin, "adminView")) {
+			$plugin->adminController();
+		}
 	}
 
 	// Load view and theme.


### PR DESCRIPTION
Hellow,

it would be really awesome if plugins are able to add custom admin pages, instead of just using the `form()` method. This could be used to develop far more extensive plugins in a defined way, without "hacking" into the booty's admin theme [as described on #1057](https://github.com/bludit/bludit/issues/1057#issuecomment-507933944).

With this pull request, the main Plugin class just needs to define the `adminController()` and `adminView()` methods to add another admin page. For example:

```php
<?php

    class SkeletonPlugin extends Plugin
    {
        public function adminController()
        {
            global $layout;
            
            // Set custom tite
            $layout["title"] = "Skeleton Plugin | Bludit";
        }
        
        public function adminView()
        {
            // Return admin page content
            return "test";
        }
    }
```

The page is available at https://bludit.tld/admin/SkeletonPlugin.

Sincerely,
Sam.