### PR TITLE
Remove async from select2

### DIFF
--- a/bl-kernel/admin/themes/booty/index.php
+++ b/bl-kernel/admin/themes/booty/index.php
@@ -34,7 +34,7 @@
 			'jquery.datetimepicker.full.min.js',
 			'select2.full.min.js',
 			'functions.js'
-		), DOMAIN_CORE_JS);
+		), DOMAIN_CORE_JS, null);
 	?>
 
 	<!-- Plugins -->


### PR DESCRIPTION
Defaulting to async is leading to buggy behaviour https://github.com/bludit/bludit/pull/1172/files

Affects Google Chrome. Maybe we should not `async` by default here - https://github.com/bludit/bludit/blob/master/bl-kernel/helpers/theme.class.php

![Screenshot_2020-06-11_20-26-58](https://user-images.githubusercontent.com/9278844/84402461-14707000-ac22-11ea-9820-fd4333249410.png)
