### PR TITLE
Allow removing Session & Cookie Entries

### DIFF
--- a/bl-kernel/helpers/cookie.class.php
+++ b/bl-kernel/helpers/cookie.class.php
@@ -20,10 +20,15 @@ class Cookie {
 		$expire = time()+60*60*24*$daysToExpire;
 		setcookie($key, $value, $expire);
 	}
+	
+	public static function remove($key)
+	{
+		unset($_COOKIE[$key]);
+		setcookie($key, null, time()-3600);
+	}
 
 	public static function isEmpty($key)
 	{
 		return empty($_COOKIE[$key]);
 	}
-
 }

--- a/bl-kernel/helpers/session.class.php
+++ b/bl-kernel/helpers/session.class.php
@@ -73,4 +73,11 @@ class Session {
 		}
 		return false;
 	}
+	
+	public static function remove($key)
+	{
+		$key = 's_'.$key;
+		
+		unset($_SESSION[$key]);
+	}
 }


### PR DESCRIPTION
Hellow,

the Cookie and especially the Session helper classes should also provide a `remove()` function. Not only to provide the full functionality, but also because the Session prefix the keys with `s_`.

Thanks.

Sincerely,
Sam.