### PR TITLE
MIME Type Check for Issue #1218 and #1212

### DIFF
--- a/bl-kernel/ajax/logo-upload.php
+++ b/bl-kernel/ajax/logo-upload.php
@@ -24,8 +24,16 @@ if (Text::stringContains($_FILES['inputFile']['name'], DS, false)) {
 // File extension
 $fileExtension = Filesystem::extension($_FILES['inputFile']['name']);
 $fileExtension = Text::lowercase($fileExtension);
-if (!in_array($fileExtension, $GLOBALS['ALLOWED_IMG_EXTENSION']) ) {
+if (!in_array($fileExtension, $GLOBALS['ALLOWED_IMG_EXTENSION'])) {
 	$message = $L->g('File type is not supported. Allowed types:').' '.implode(', ',$GLOBALS['ALLOWED_IMG_EXTENSION']);
+	Log::set($message, LOG_TYPE_ERROR);
+	ajaxResponse(1, $message);
+}
+
+// File MIME Type
+$fileMimeType = Filesystem::mimeType($_FILES['inputFile']['tmp_name']);
+if (!in_array($fileMimeType, $GLOBALS['ALLOWED_IMG_MIMETYPES'])) {
+	$message = $L->g('File mime type is not supported. Allowed types:').' '.implode(', ',$GLOBALS['ALLOWED_IMG_MIMETYPES']);
 	Log::set($message, LOG_TYPE_ERROR);
 	ajaxResponse(1, $message);
 }

--- a/bl-kernel/ajax/profile-picture-upload.php
+++ b/bl-kernel/ajax/profile-picture-upload.php
@@ -35,6 +35,14 @@ if (!in_array($fileExtension, $GLOBALS['ALLOWED_IMG_EXTENSION']) ) {
 	ajaxResponse(1, $message);
 }
 
+// Check file MIME Type
+$fileMimeType = Filesystem::mimeType($_FILES['profilePictureInputFile']['tmp_name']);
+if (!in_array($fileMimeType, $GLOBALS['ALLOWED_IMG_MIMETYPES'])) {
+	$message = $L->g('File mime type is not supported. Allowed types:').' '.implode(', ',$GLOBALS['ALLOWED_IMG_MIMETYPES']);
+	Log::set($message, LOG_TYPE_ERROR);
+	ajaxResponse(1, $message);
+}
+
 // Tmp filename
 $tmpFilename = $username.'.'.$fileExtension;
 

--- a/bl-kernel/ajax/upload-images.php
+++ b/bl-kernel/ajax/upload-images.php
@@ -63,6 +63,14 @@ foreach ($_FILES['images']['name'] as $uuid=>$filename) {
 		ajaxResponse(1, $message);
 	}
 
+	// Check file MIME Type
+	$fileMimeType = Filesystem::mimeType($_FILES['images']['tmp_name'][$uuid]);
+	if (!in_array($fileMimeType, $GLOBALS['ALLOWED_IMG_MIMETYPES'])) {
+		$message = $L->g('File mime type is not supported. Allowed types:').' '.implode(', ',$GLOBALS['ALLOWED_IMG_MIMETYPES']);
+		Log::set($message, LOG_TYPE_ERROR);
+		ajaxResponse(1, $message);
+	}
+
 	// Move from PHP tmp file to Bludit tmp directory
 	Filesystem::mv($_FILES['images']['tmp_name'][$uuid], PATH_TMP.$filename);
 

--- a/bl-kernel/boot/variables.php
+++ b/bl-kernel/boot/variables.php
@@ -108,3 +108,6 @@ $GLOBALS['DB_TAGS_TYPES'] = array('published','static','sticky');
 
 // Allowed image extensions
 $GLOBALS['ALLOWED_IMG_EXTENSION'] = array('gif', 'png', 'jpg', 'jpeg', 'svg');
+
+// Allowed image mime types
+$GLOBALS['ALLOWED_IMG_MIMETYPES'] = array('image/gif', 'image/png', 'image/jpeg', 'image/svg+xml');


### PR DESCRIPTION
Hellow,

this pull request adds a File MIME Type check to all 3 AJAX requests to prevent file injection as described in #1218 and #1212. 

- `logo-upload.php`
- `profile-picture-upload.php`
- `upload-images.php`

It also adds a new GLOBAL variable called `ALLOWED_IMG_MIMETYPES` with the respective allowed types: `image/gif`, `image/png`, `image/jpeg` and `image/svg+xml`.

~ Sam.