### PR TITLE
Fix for issue #1216 - ModSecurity Rule

### DIFF
--- a/bl-kernel/admin/views/settings.php
+++ b/bl-kernel/admin/views/settings.php
@@ -1,6 +1,6 @@
 <?php defined('BLUDIT') or die('Bludit CMS.'); ?>
 
-<?php echo Bootstrap::formOpen(array('id'=>'jsform', 'class'=>'tab-content')); ?>
+<?php echo Bootstrap::formOpen(array('id'=>'jsform', 'class'=>'tab-content', 'action'=>'settings.php')); ?>
 
 <div class="align-middle">
 	<div class="float-right mt-1">

--- a/bl-kernel/helpers/text.class.php
+++ b/bl-kernel/helpers/text.class.php
@@ -102,8 +102,9 @@ class Text {
 
 	public static function endsWith($string, $endsString)
 	{
-		//$length = (-1)*self::length($endsString);
-		return (mb_substr($string, -1)===$endsString);
+		$length = self::length($endsString);
+
+		return (mb_substr($string, -$length)===$endsString);
 	}
 
 	public static function endsWithNumeric($string)

--- a/bl-kernel/url.class.php
+++ b/bl-kernel/url.class.php
@@ -78,6 +78,10 @@ class Url
 				} elseif (!empty($this->slug) && ($filterURI=='/')) {
 					$this->setWhereAmI('page');
 				} elseif ($filterName=='admin') {
+					if (Text::endsWith($this->uri, '.php')) {
+						$this->uri = mb_substr($this->uri, 0, -4);
+						$this->slug = mb_substr($this->slug, 0, -4);
+					}
 					$this->slug = ltrim($this->slug, '/');
 				}
 


### PR DESCRIPTION
Hellow,

this pull request fix issue #1216, by changing the form attribute `action` to `settings.php` and allowing to use the `.php` extension on the backend only. This fulfils the [modSecurity Rule Filter](https://github.com/pfsense/pfsense-packages/blob/903855b9b2d726f09594f6caccad8015b6063ca8/config/apache_mod_security/rules/10_asl_rules.conf#L3470) (see WAF-Rule [340162 - Remote File Injection Attack detected](https://github.com/pfsense/pfsense-packages/blob/903855b9b2d726f09594f6caccad8015b6063ca8/config/apache_mod_security/rules/10_asl_rules.conf#L690)), which gets applied when URLs are sent to the server.

It also changes the `Text::endsWith` helper method, which allows using end substrings which are longer than 1 character (as it is also possible on the `Text::startsWith` method).

~ Sam.