### PR TITLE
Extend plugins hook

### DIFF
--- a/bl-kernel/functions.php
+++ b/bl-kernel/functions.php
@@ -321,7 +321,7 @@ function createPage($args) {
 	$key = $pages->add($args);
 	if ($key) {
 		// Call the plugins after page created
-		Theme::plugins('afterPageCreate');
+		Theme::plugins('afterPageCreate', array($key));
 
 		reindexCategories();
 		reindexTags();
@@ -371,7 +371,7 @@ function editPage($args) {
 	$key = $pages->edit($args);
 	if ($key) {
 		// Call the plugins after page modified
-		Theme::plugins('afterPageModify');
+		Theme::plugins('afterPageModify', array($key));
 
 		reindexCategories();
 		reindexTags();
@@ -392,10 +392,10 @@ function editPage($args) {
 function deletePage($key) {
 	global $pages;
 	global $syslog;
-
+	 
 	if ($pages->delete($key)) {
 		// Call the plugins after page deleted
-		Theme::plugins('afterPageDelete');
+		Theme::plugins('afterPageDelete', array($key));
 
 		reindexCategories();
 		reindexTags();

--- a/bl-kernel/helpers/theme.class.php
+++ b/bl-kernel/helpers/theme.class.php
@@ -225,11 +225,11 @@ class Theme {
 		return self::javascript($files, $base, $attributes);
 	}
 
-	public static function plugins($type)
+	public static function plugins($type, $args = array())
 	{
 		global $plugins;
 		foreach ($plugins[$type] as $plugin) {
-			echo call_user_func(array($plugin, $type));
+			echo call_user_func_array(array($plugin, $type), $args);
 		}
 	}
 


### PR DESCRIPTION
Hellow,

after playing with the `afterPage*` plugin hooks, I figured out that it is not possible to get the key of a new created, modified or deleted page. I played a bit around and found the following solution, which not only helps to work with the `afterPage*` hooks but also extends the plugin hook API in general.

Now you can pass additional arguments, and use them within the respective function, something like...

```php
<?php

    class MyPlugin extends Plugin {

        public function afterPageCreate($key) {
            $page = new Page($key);

            // Work with the Page Object
        }
        
    }
```

Would be really cool to have.

~ Sam.