### PR TITLE
Allow dots in URL

### DIFF
--- a/bl-kernel/helpers/text.class.php
+++ b/bl-kernel/helpers/text.class.php
@@ -176,7 +176,7 @@ class Text {
 			}
 		}
 
-		$string = preg_replace("/[^a-zA-Z0-9\/_|+ -]/", '', $string);
+		$string = preg_replace("/[^a-zA-Z0-9\/_|+. -]/", '', $string);
 		$string = self::lowercase($string);
 		$string = preg_replace("/[\/_|+ -]+/", $separator, $string);
 		$string = trim($string, '-');


### PR DESCRIPTION
Hellow,

this pull request allows using dots in the `Text` helper method `cleanUrl()`, this would also allow us to use dots on slugs and page key names. 

### Advantages
- The page author is not restricted and can force dots if needed
  - For example if he reviews domains - `https://www.example.com/review/google.com`
  - For example if a product contains a styling - `https://www.codeblu.dev/plugins/tail.writer`
  - For example if a dot would look better - `https://www.example.com/talking-about.dots`
- The page author can 'pretend' static .html pages using `.html`

### Disadvantages
- He should try to avoid `index.php` or `install.php`, which cannot happen unintentionally ;)

If the user doesn't want to use dots, or if the admin wants to avoid them - for example on a Bludit website with multiple authors - he can still enable the `Extreme friendly URL` option on the admin page.

Would be really awesome. Thanks.

~ Sam.