### PR TITLE
[Plugin] Add Authentication using IMAP server

### DIFF
--- a/bl-kernel/boot/rules/60.plugins.php
+++ b/bl-kernel/boot/rules/60.plugins.php
@@ -37,6 +37,9 @@ $plugins = array(
 	'loginBodyBegin'=>array(),
 	'loginBodyEnd'=>array(),
 
+	'beforeVerifyUser'=>array(),
+	'afterVerifyUser'=>array(),
+
 	'all'=>array()
 );
 

--- a/bl-kernel/login.class.php
+++ b/bl-kernel/login.class.php
@@ -104,6 +104,13 @@ class Login {
 			return false;
 		}
 
+        try {
+            Theme::plugins('beforeVerifyUser');
+        } catch (Exception $e) {
+            Log::set($e->getFile().LOG_SEP.$e->getLine().LOG_SEP.$e->getMessage());
+            return false;
+        }
+
 		try {
 			$user = new User($username);
 		} catch (Exception $e) {
@@ -117,7 +124,17 @@ class Login {
 			return true;
 		}
 
-		Log::set(__METHOD__.LOG_SEP.'Password incorrect.');
+        try {
+            Theme::plugins('afterVerifyUser');
+        } catch (Exception $e) {
+            Log::set($e->getFile().LOG_SEP.$e->getLine().LOG_SEP.$e->getMessage());
+            return false;
+        }
+		if ($this->isLogged()) {
+		    return true;
+        }
+
+        Log::set(__METHOD__.LOG_SEP.'Password incorrect.');
 		return false;
 	}
 

--- a/bl-plugins/imap-authentication/languages/de.json
+++ b/bl-plugins/imap-authentication/languages/de.json
@@ -1,0 +1,9 @@
+{
+  "plugin-data":
+  {
+    "name": "IMAP-Authentifizierung",
+    "description": "Dieses Plugin ermöglicht die Authentifizierung von Benutzern mit Hilfe eines IMAP-Servers.",
+    "imap-server": "IMAP Server",
+    "encryption": "Verschlüsselung"
+  }
+}

--- a/bl-plugins/imap-authentication/languages/en.json
+++ b/bl-plugins/imap-authentication/languages/en.json
@@ -1,0 +1,9 @@
+{
+  "plugin-data":
+  {
+    "name": "IMAP Authentication",
+    "description": "This plugin enables the authentication of users, using an IMAP server.",
+    "imap-server": "IMAP Server",
+    "encryption": "Encryption"
+  }
+}

--- a/bl-plugins/imap-authentication/metadata.json
+++ b/bl-plugins/imap-authentication/metadata.json
@@ -1,0 +1,10 @@
+{
+  "author": "LeineLab",
+  "email": "",
+  "website": "https://leinelab.org",
+  "version": "0.1.0",
+  "releaseDate": "2020-06-15",
+  "license": "MIT",
+  "compatible": "3.12.0",
+  "notes": ""
+}

--- a/bl-plugins/imap-authentication/plugin.php
+++ b/bl-plugins/imap-authentication/plugin.php
@@ -1,0 +1,148 @@
+<?php
+
+class pluginImapAuthentication extends Plugin {
+
+    const IMAP_SERVER_DB_FIELD = 'imapServer';
+    const IMAP_ENCRYPTION_DB_FIELD = 'imapEncryption';
+
+    public function init()
+    {
+        $this->dbFields = array(
+            self::IMAP_SERVER_DB_FIELD=>'',
+            self::IMAP_ENCRYPTION_DB_FIELD=>'ssl',
+        );
+    }
+
+    public function form()
+    {
+        global $L;
+
+        $html  = '<div class="alert alert-primary" role="alert">';
+        $html .= $this->description();
+        $html .= '</div>';
+
+        $html .= '<div>';
+        $html .= '<label>'.$L->get('IMAP Server').'</label>';
+        $html .= '<input name="imapServer" id="imapServer" type="text" value="'.$this->getValue(self::IMAP_SERVER_DB_FIELD).'">';
+        $html .= '</div>';
+
+        $html .= '<div>';
+        $html .= '<label>'.$L->get('Encryption').'</label>';
+        $html .= '<select name="imapEncryption" id="imapEncryption">';
+        $html .= '<option value="ssl" '.('ssl' === $this->getValue(self::IMAP_ENCRYPTION_DB_FIELD) ? 'selected' : ''). '>SSL</option>';
+        $html .= '<option value="tls" '.('tls' === $this->getValue(self::IMAP_ENCRYPTION_DB_FIELD) ? 'selected' : ''). '>TLS</option>';
+        $html .= '</select>';
+        $html .= '</div>';
+
+        return $html;
+    }
+
+    /**
+     * Before validating user, check if exists.
+     * If not and the user name is an email
+     * and has an IMAP account create one.
+     * @throws Exception
+     */
+    public function beforeVerifyUser()
+    {
+        $username = $_POST['username'];
+        $password = $_POST['password'];
+
+        if (false === filter_var($username, FILTER_VALIDATE_EMAIL)) {
+            return;
+        }
+
+        try {
+            new User($username);
+        } catch (Exception $e) {
+            $this->createUser($username, $password);
+        }
+    }
+
+    /**
+     * Validate user using IMAP
+     * @throws Exception
+     */
+    public function afterVerifyUser()
+    {
+        $username = $_POST['username'];
+        $password = $_POST['password'];
+
+        if (!$this->authenticateUser($this->getValue(self::IMAP_SERVER_DB_FIELD), $this->getValue(self::IMAP_ENCRYPTION_DB_FIELD), $username, $password)) {
+            return;
+        }
+
+        $user = new User($username);
+
+        $loginClass = new login();
+        $loginClass->setLogin($username, $user->role());
+        Log::set(__METHOD__.LOG_SEP.'Successful user login using IMAP - Username ['.$username.']');
+    }
+
+    /**
+     * @param $mailbox
+     * @param $encryption
+     * @param $username User's mail address
+     * @param $password
+     * @return bool
+     */
+    private function authenticateUser($mailbox, $encryption, $username, $password)
+    {
+        if (!function_exists('imap_open')) {
+            Log::set(__METHOD__.LOG_SEP.'ERROR: PHP imap extension is not installed');
+        }
+
+        // Replace escaped @ symbol in uid (which is a mail address)
+        // but only if there is no @ symbol and if there is a %40 inside the uid
+        if (!(strpos($username, '@') !== false) && (strpos($username, '%40') !== false)) {
+            $username = str_replace("%40","@",$username);
+        }
+
+        $imapConnection = @imap_open("{{$mailbox}/imap/{$encryption}}INBOX", $username, $password, OP_HALFOPEN, 1);
+        $imapErrors = imap_errors();
+        $imapAlerts = imap_alerts();
+        if (!empty($imapErrors)) {
+            Log::set(__METHOD__.LOG_SEP."IMAP Error:\n".print_r($imapErrors, true));
+        }
+        if (!empty($imapAlerts)) {
+            Log::set(__METHOD__.LOG_SEP."WARNING: IMAP Warning:\n".print_r($imapAlerts, true));
+        }
+        if($imapConnection !== false) {
+            imap_close($imapConnection);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param $username User's mail address
+     * @param $password
+     * @throws Exception
+     */
+    private function createUser($username, $password)
+    {
+        global $users;
+
+        if (!$this->authenticateUser($this->getValue(self::IMAP_SERVER_DB_FIELD), $this->getValue(self::IMAP_ENCRYPTION_DB_FIELD), $username, $password)) {
+            return;
+        }
+
+        $usersClass = new Users();
+        $usersClass->add(array(
+            'username' => $username,
+            'password' => '',
+            'email' => $username,
+            'nickname' => explode('@', $username)[0]
+        ));
+
+        $users = new Users();
+
+        $user = new User($username);
+
+        $loginClass = new Login();
+        $loginClass->setLogin($username, $user->role());
+        Log::set(__METHOD__.LOG_SEP.'Successful user creation using IMAP - Username ['.$username.']');
+    }
+}


### PR DESCRIPTION
This plugin enables the authentication with an IMAP server. It's tested and being used in https://blog.leinelab.org/

In order to achieve this some changes in the core were necessary.

2 new hooks were introduced in `bl-kernel/boot/rules/60.plugins.php `
- `beforeVerifyUser`
- `afterVerifyUser`

These hooks are used in the `bl-kernel/login.class.php`.

These core changes enable more plugins to hook into the authentication process and work complimentary with the default (database) authentication.

The plugin has 2 DB fields in which the server and the encryption is saved. It uses `imap_open` to connect to the IMAP server and verify the given credentials.

![Plugin configuration](https://user-images.githubusercontent.com/645895/95794968-784a9880-0ce9-11eb-9970-9f03e1ac7f0c.png)

