### PR TITLE
feat: Allow images to be inserted as thumbnails or as linked thumbnails

### DIFF
--- a/bl-kernel/admin/themes/booty/html/media.php
+++ b/bl-kernel/admin/themes/booty/html/media.php
@@ -108,6 +108,8 @@ function displayFiles(files, numberOfPages = <?= $numberOfPages ?>) {
 						'<div class="text-primary pb-2">'+filename+'<\/div>'+
 						'<div>'+
 							'<a href="#" class="mr-3 text-secondary" onClick="editorInsertMedia(\''+image+'\'); closeMediaManager();"><i class="fa fa-plus"></i><?php $L->p('Insert') ?><\/a>'+
+							'<a href="#" class="mr-3 text-secondary" onClick="editorInsertMedia(\''+thumbnail+'\'); closeMediaManager();"><i class="fa fa-search"></i><?php $L->p('Insert thumbnail') ?><\/a>'+
+							'<a href="#" class="mr-3 text-secondary" onClick="editorInsertLinkedMedia(\''+thumbnail+'\',\''+image+'\'); closeMediaManager();"><i class="fa fa-link"></i><?php $L->p('Insert linked thumbnail') ?><\/a>'+
 							'<a href="#" class="text-secondary" onClick="setCoverImage(\''+filename+'\'); closeMediaManager();"><i class="fa fa-square-o"></i><?php $L->p('Set as cover image') ?><\/button>'+
 							'<a href="#" class="float-right text-danger" onClick="deleteMedia(\''+filename+'\')"><i class="fa fa-trash-o"></i><?php $L->p('Delete') ?><\/a>'+
 						'<\/div>'+

--- a/bl-kernel/admin/views/edit-content.php
+++ b/bl-kernel/admin/views/edit-content.php
@@ -478,6 +478,11 @@ $(document).ready(function() {
 			$("#jseditor").val($('#jseditor').val()+'<img src="'+filename+'" alt="">');
 		};
 	}
+	if (typeof editorInsertLinkedMedia != "function") {
+		window.editorInsertLinkedMedia = function(filename, link){
+			$("#jseditor").val($('#jseditor').val()+'<a href="'+link+'"><img src="'+filename+'" alt=""></a>');
+		};
+	}
 
 	// Button switch
 	$("#jsswitchButton").on("click", function() {

--- a/bl-kernel/admin/views/new-content.php
+++ b/bl-kernel/admin/views/new-content.php
@@ -434,6 +434,11 @@ $(document).ready(function() {
 			$("#jseditor").val($('#jseditor').val()+'<img src="'+filename+'" alt="">');
 		};
 	}
+	if (typeof editorInsertLinkedMedia != "function") {
+		window.editorInsertLinkedMedia = function(filename, link){
+			$("#jseditor").val($('#jseditor').val()+'<a href="'+link+'"><img src="'+filename+'" alt=""></a>');
+		};
+	}
 
 	// Button switch
 	$("#jsbuttonSwitch").on("click", function() {

--- a/bl-languages/de_AT.json
+++ b/bl-languages/de_AT.json
@@ -392,5 +392,7 @@
     "custom-fields": "Benutzerdefinierte Felder",
     "define-custom-fields-for-the-content": "Benutzerdefinierte Felder für Inhalte anlegen. Informationen darüber sind in der <a href='https:\/\/docs.bludit.com\/en\/content\/custom-fields'>Dokumentation<\/a> zu finden.",
     "start-typing-to-see-a-list-of-suggestions": "Beginne mit dem Tippen für eine Liste mit Vorschlägen.",
-    "view": "Anschauen"
+    "view": "Anschauen",
+    "insert-thumbnail": "Vorschau einfügen",
+    "insert-linked-thumbnail": "Verlinkte Vorschau einfügen"
 }

--- a/bl-languages/de_CH.json
+++ b/bl-languages/de_CH.json
@@ -392,5 +392,7 @@
     "custom-fields": "Benutzerdefinierte Felder",
     "define-custom-fields-for-the-content": "Benutzerdefinierte Felder für Inhalte anlegen. Informationen darüber sind in der <a href='https:\/\/docs.bludit.com\/en\/content\/custom-fields'>Dokumentation<\/a> zu finden.",
     "start-typing-to-see-a-list-of-suggestions": "Beginne mit dem Tippen für eine Liste mit Vorschlägen.",
-    "view": "Anschauen"
+    "view": "Anschauen",
+    "insert-thumbnail": "Vorschau einfügen",
+    "insert-linked-thumbnail": "Verlinkte Vorschau einfügen"
 }

--- a/bl-languages/de_DE.json
+++ b/bl-languages/de_DE.json
@@ -392,5 +392,7 @@
     "custom-fields": "Benutzerdefinierte Felder",
     "define-custom-fields-for-the-content": "Benutzerdefinierte Felder für Inhalte anlegen. Informationen darüber sind in der <a href='https:\/\/docs.bludit.com\/en\/content\/custom-fields'>Dokumentation<\/a> zu finden.",
     "start-typing-to-see-a-list-of-suggestions": "Beginne mit dem Tippen für eine Liste mit Vorschlägen.",
-    "view": "Anschauen"
+    "view": "Anschauen",
+    "insert-thumbnail": "Vorschau einfügen",
+    "insert-linked-thumbnail": "Verlinkte Vorschau einfügen"
 }

--- a/bl-languages/en.json
+++ b/bl-languages/en.json
@@ -391,5 +391,7 @@
     "custom-fields": "Custom fields",
     "define-custom-fields-for-the-content": "Define custom fields for the content. Learn more about custom fields in the <a href='https:\/\/docs.bludit.com\/en\/content\/custom-fields'>documentation<\/a>.",
     "start-typing-to-see-a-list-of-suggestions": "Start typing to see a list of suggestions.",
-    "view": "View"
+    "view": "View",
+    "insert-thumbnail": "Insert thumbnail",
+    "insert-linked-thumbnail": "Insert linked thumbnail"
 }

--- a/bl-plugins/tinymce/plugin.php
+++ b/bl-plugins/tinymce/plugin.php
@@ -86,6 +86,12 @@ $html = <<<EOF
 		tinymce.activeEditor.insertContent("<img src=\""+filename+"\" alt=\"\">");
 	}
 
+	// Insert a linked image in the editor at the cursor position
+	// Function required for Bludit
+	function editorInsertLinkedMedia(filename, link) {
+		tinymce.activeEditor.insertContent("<a href=\""+link+"\"><img src=\""+filename+"\" alt=\"\"></a>");
+	}
+
 	// Returns the content of the editor
 	// Function required for Bludit
 	function editorGetContent() {


### PR DESCRIPTION
When inserting an image into a page, the image will be inserted using the original size. This slows down the page load if many large images are inserted.
Two new options allow the user to insert thumbnails instead, either with a link or without a link to the original image.
German translations are included.