### PR TITLE
Custom Field as "Textarea"

### DIFF
--- a/bl-kernel/admin/views/edit-content.php
+++ b/bl-kernel/admin/views/edit-content.php
@@ -311,7 +311,17 @@ echo Bootstrap::formOpen(array(
 							'checked'=>$page->custom($field),
 							'labelForCheckbox'=>(isset($options['tip'])?$options['tip']:'')
 						));
-					}
+					} elseif ($options['type']=="text") {
+					  echo Bootstrap::formTextareaBlock(array(
+              'name'=>'custom['.$field.']',
+              'value'=>(isset($options['default'])?$options['default']:''),
+              'tip'=>(isset($options['tip'])?$options['tip']:''),
+              'label'=>(isset($options['label'])?$options['label']:''),
+              'placeholder'=>(isset($options['placeholder'])?$options['placeholder']:''),
+              'value'=>$page->custom($field),
+              'rows'=>'4'
+            ));
+				  }
 				}
 			}
 		?>
@@ -377,7 +387,6 @@ echo Bootstrap::formOpen(array(
 					'placeholder'=>(isset($options['placeholder'])?$options['placeholder']:''),
 					'class'=>'mb-2',
 					'labelClass'=>'mb-2 pb-2 border-bottom text-uppercase w-100'
-
 				));
 			} elseif ($options['type']=="bool") {
 				echo Bootstrap::formCheckbox(array(
@@ -389,7 +398,19 @@ echo Bootstrap::formOpen(array(
 					'class'=>'mb-2',
 					'labelClass'=>'mb-2 pb-2 border-bottom text-uppercase w-100'
 				));
-			}
+			} elseif ($options['type']=="text") {
+					echo Bootstrap::formTextareaBlock(array(
+						'name'=>'custom['.$field.']',
+						'value'=>(isset($options['default'])?$options['default']:''),
+						'tip'=>(isset($options['tip'])?$options['tip']:''),
+						'label'=>(isset($options['label'])?$options['label']:''),
+						'placeholder'=>(isset($options['placeholder'])?$options['placeholder']:''),
+						'value'=>$page->custom($field),
+						'rows'=>'4',
+            'class'=>'mb-2',
+   					'labelClass'=>'mb-2 pb-2 border-bottom text-uppercase w-100'
+					));
+				}
 		}
 	}
 ?>
@@ -416,7 +437,6 @@ echo Bootstrap::formOpen(array(
 					'placeholder'=>(isset($options['placeholder'])?$options['placeholder']:''),
 					'class'=>'mt-2',
 					'labelClass'=>'mb-2 pb-2 border-bottom text-uppercase w-100'
-
 				));
 			} elseif ($options['type']=="bool") {
 				echo Bootstrap::formCheckbox(array(
@@ -428,7 +448,19 @@ echo Bootstrap::formOpen(array(
 					'class'=>'mt-2',
 					'labelClass'=>'mb-2 pb-2 border-bottom text-uppercase w-100'
 				));
-			}
+			} elseif ($options['type']=="text") {
+					echo Bootstrap::formTextareaBlock(array(
+						'name'=>'custom['.$field.']',
+						'value'=>(isset($options['default'])?$options['default']:''),
+						'tip'=>(isset($options['tip'])?$options['tip']:''),
+						'label'=>(isset($options['label'])?$options['label']:''),
+						'placeholder'=>(isset($options['placeholder'])?$options['placeholder']:''),
+						'value'=>$page->custom($field),
+						'rows'=>'4',
+            'class'=>'mt-2',
+            'labelClass'=>'mb-2 pb-2 border-bottom text-uppercase w-100'
+					));
+				}
 		}
 	}
 ?>


### PR DESCRIPTION
Allows to add a textarea as custom field.
In custom field settings use "text" as type _("type": "text")_.

The textarea has a height of 4 rows.