### PR TITLE
Fix logo filename to avoid W3 validator error

### DIFF
--- a/bl-kernel/admin/views/settings.php
+++ b/bl-kernel/admin/views/settings.php
@@ -443,6 +443,15 @@
 	<!-- Images tab -->
 	<div class="tab-pane fade" id="images" role="tabpanel" aria-labelledby="images-tab">
 	<?php
+		echo Bootstrap::formCheckbox(array(
+			'name'=>'renameImageWithHash',
+      'label'=>'',
+			'labelForCheckbox'=>$L->g('rename-new-images-and-thumbnails-with-hash'),
+			'checked'=>$site->renameImageWithHash(),
+			'placeholder'=>'',
+			'tip'=>$L->g('Activate').' / '.$L->g('Deactivate')
+		));
+
 		echo Bootstrap::formTitle(array('title'=>$L->g('Thumbnails')));
 
 		echo Bootstrap::formInputText(array(

--- a/bl-kernel/ajax/logo-upload.php
+++ b/bl-kernel/ajax/logo-upload.php
@@ -43,7 +43,7 @@ if ($fileMimeType!==false) {
 // Final filename
 $filename = 'logo.'.$fileExtension;
 if (Text::isNotEmpty( $site->title() )) {
-	$filename = $site->title().'.'.$fileExtension;
+	$filename = preg_replace('/[^A-Za-z0-9-]+/', '-', $site->title()).'.'.$fileExtension;
 }
 
 // Delete old image

--- a/bl-kernel/functions.php
+++ b/bl-kernel/functions.php
@@ -879,7 +879,7 @@ function transformImage($file, $imageDir, $thumbnailDir=false) {
 
 	// Generate a filename to not overwrite current image if exists
 	$filename = Filesystem::filename($file);
-	$nextFilename = Filesystem::nextFilename($imageDir, $filename);
+	$nextFilename = Filesystem::nextFilename($imageDir, $filename, $site->renameImageWithHash());
 
 	// Move the image to a proper place and rename
 	$image = $imageDir.$nextFilename;

--- a/bl-kernel/helpers/filesystem.class.php
+++ b/bl-kernel/helpers/filesystem.class.php
@@ -217,13 +217,17 @@ class Filesystem {
          |
          | @return	string
          */
-	public static function nextFilename($path=PATH_UPLOADS, $filename) {
+	public static function nextFilename($path=PATH_UPLOADS, $filename, $hash=false) {
 		// Clean filename and get extension
 		$fileExtension 	= pathinfo($filename, PATHINFO_EXTENSION);
 		$fileExtension 	= Text::lowercase($fileExtension);
 		$filename 	= pathinfo($filename, PATHINFO_FILENAME);
 		$filename 	= Text::removeSpaces($filename);
 		$filename 	= Text::removeQuotes($filename);
+
+    if ($hash) {
+      $filename = md5($filename);
+    }
 
 		// Search for the next filename
 		$tmpName = $filename.'.'.$fileExtension;

--- a/bl-kernel/site.class.php
+++ b/bl-kernel/site.class.php
@@ -43,6 +43,7 @@ class Site extends dbJSON {
 		'titleFormatTag'=> 	'{{tag-name}} | {{site-title}}',
 		'imageRestrict'=>	true,
 		'imageRelativeToAbsolute'=> false,
+    'renameImageWithHash' => false,
 		'thumbnailWidth'=> 	400, // px
 		'thumbnailHeight'=> 	400, // px
 		'thumbnailQuality'=> 	100,
@@ -117,6 +118,11 @@ class Site extends dbJSON {
 	public function sitemap()
 	{
 		return DOMAIN_BASE.'sitemap.xml';
+	}
+
+	public function renameImageWithHash()
+	{
+		return $this->getField('renameImageWithHash');
 	}
 
 	public function thumbnailWidth()

--- a/bl-languages/en.json
+++ b/bl-languages/en.json
@@ -376,6 +376,7 @@
     "thumbnail-width-in-pixels": "Thumbnail width in pixels (px).",
     "thumbnail-height-in-pixels": "Thumbnail height in pixels (px).",
     "thumbnail-quality-in-percentage": "Thumbnail quality in percentage (%).",
+    "rename-new-images-and-thumbnails-with-hash": "Rename new images and thumbnails with hash",
     "maximum-load-file-size-allowed:": "Maximum load file size allowed:",
     "file-type-is-not-supported": "File type is not supported. Allowed types:",
     "page-content": "Page content",

--- a/bl-languages/fr_FR.json
+++ b/bl-languages/fr_FR.json
@@ -376,6 +376,7 @@
     "thumbnail-width-in-pixels": "Largeur de la miniature en pixels (px).",
     "thumbnail-height-in-pixels": "Hauteur de la miniature en pixels (px).",
     "thumbnail-quality-in-percentage": "Qualité des miniatures en pourcentage (%).",
+    "rename-new-images-and-thumbnails-with-hash": "Renommer les nouvelles images et miniatures avec un hash",
     "maximum-load-file-size-allowed:": "Taille maximale des fichiers autorisée :",
     "file-type-is-not-supported": "Le type de fichier n’est pas supporté. Liste des extensions autorisées :",
     "page-content": "Contenu de la page",


### PR DESCRIPTION
Set the logo filename as site title can generate an error on the W3 validator if the site title contains special chars like "!", etc.

To avoid that, I keep only alnum chars and "-" to name the logo file.