### PR TITLE
Better HTTPS detection when running behind a reverse proxy

### DIFF
--- a/install.php
+++ b/install.php
@@ -67,10 +67,12 @@ define('FILENAME', 'index.txt');
 // Domain and protocol
 define('DOMAIN', $_SERVER['HTTP_HOST']);
 
-if (!empty($_SERVER['HTTPS'])) {
-	define('PROTOCOL', 'https://');
+if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on'
+    || !empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https'
+    || !empty($_SERVER['HTTP_X_FORWARDED_SSL']) && $_SERVER['HTTP_X_FORWARDED_SSL'] == 'on') {
+    define('PROTOCOL', 'https://');
 } else {
-	define('PROTOCOL', 'http://');
+    define('PROTOCOL', 'http://');
 }
 
 // Base URL


### PR DESCRIPTION
I'm using Bludit inside a docker container behind a traefik reverse proxy. In this case, the HTTPS detection fails and css is not loaded because urls start with http instead of https.