### PR TITLE
fix 'mitatbeiter' typo in german (DE,AT & CH) locale files

### DIFF
--- a/bl-languages/de_AT.json
+++ b/bl-languages/de_AT.json
@@ -388,7 +388,7 @@
     "disabled-plugins": "Deaktivierte Plugins",
     "remove-logo": "Logo entfernen",
     "preview": "Vorschau",
-    "author-can-write-and-edit-their-own-content": "Autor: Kann Inhalte erstellen und seine eigenen bearbeiten. Mitatbeiter: Kann Inhalte erstellen und seine eigenen und die anderer bearbeiten.",
+    "author-can-write-and-edit-their-own-content": "Autor: Kann Inhalte erstellen und seine eigenen bearbeiten. Mitarbeiter: Kann Inhalte erstellen und seine eigenen und die anderer bearbeiten.",
     "custom-fields": "Benutzerdefinierte Felder",
     "define-custom-fields-for-the-content": "Benutzerdefinierte Felder für Inhalte anlegen. Informationen darüber sind in der <a href='https:\/\/docs.bludit.com\/en\/content\/custom-fields'>Dokumentation<\/a> zu finden.",
     "start-typing-to-see-a-list-of-suggestions": "Beginne mit dem Tippen für eine Liste mit Vorschlägen.",

--- a/bl-languages/de_CH.json
+++ b/bl-languages/de_CH.json
@@ -388,7 +388,7 @@
     "disabled-plugins": "Deaktivierte Plugins",
     "remove-logo": "Logo entfernen",
     "preview": "Vorschau",
-    "author-can-write-and-edit-their-own-content": "Autor: Kann Inhalte erstellen und seine eigenen bearbeiten. Mitatbeiter: Kann Inhalte erstellen und seine eigenen und die anderer bearbeiten.",
+    "author-can-write-and-edit-their-own-content": "Autor: Kann Inhalte erstellen und seine eigenen bearbeiten. Mitarbeiter: Kann Inhalte erstellen und seine eigenen und die anderer bearbeiten.",
     "custom-fields": "Benutzerdefinierte Felder",
     "define-custom-fields-for-the-content": "Benutzerdefinierte Felder für Inhalte anlegen. Informationen darüber sind in der <a href='https:\/\/docs.bludit.com\/en\/content\/custom-fields'>Dokumentation<\/a> zu finden.",
     "start-typing-to-see-a-list-of-suggestions": "Beginne mit dem Tippen für eine Liste mit Vorschlägen.",

--- a/bl-languages/de_DE.json
+++ b/bl-languages/de_DE.json
@@ -388,7 +388,7 @@
     "disabled-plugins": "Deaktivierte Plugins",
     "remove-logo": "Logo entfernen",
     "preview": "Vorschau",
-    "author-can-write-and-edit-their-own-content": "Autor: Kann Inhalte erstellen und seine eigenen bearbeiten. Mitatbeiter: Kann Inhalte erstellen und seine eigenen und die anderer bearbeiten.",
+    "author-can-write-and-edit-their-own-content": "Autor: Kann Inhalte erstellen und seine eigenen bearbeiten. Mitarbeiter: Kann Inhalte erstellen und seine eigenen und die anderer bearbeiten.",
     "custom-fields": "Benutzerdefinierte Felder",
     "define-custom-fields-for-the-content": "Benutzerdefinierte Felder für Inhalte anlegen. Informationen darüber sind in der <a href='https:\/\/docs.bludit.com\/en\/content\/custom-fields'>Dokumentation<\/a> zu finden.",
     "start-typing-to-see-a-list-of-suggestions": "Beginne mit dem Tippen für eine Liste mit Vorschlägen.",


### PR DESCRIPTION
This pull request will just fix the 'mitatbeiter' typo in german local files