### PR TITLE
Missing comma - it shows the errors at installation page

### DIFF
--- a/bl-languages/nl_NL.json
+++ b/bl-languages/nl_NL.json
@@ -388,7 +388,7 @@
     "custom-fields": "Eigen velden",
     "define-custom-fields-for-the-content": "Definieer eigen inhoudsvelden. Lees meer over eigen velden in de <a href='https:\/\/docs.bludit.com\/en\/content\/custom-fields'>documentatie<\/a>.",
     "start-typing-to-see-a-list-of-suggestions": "Voer de beginletters in om een lijst met suggesties op te roepen.",
-    "view": "Bekijken"
+    "view": "Bekijken",
     "insert-thumbnail": "Thumbnail invoegen",
     "insert-linked-thumbnail": "Thumbnail met link invoegen"
 }


### PR DESCRIPTION
Missing comma and it shows the errors at installation page,
It seems some people also face [this issue here](https://forum.bludit.org/viewtopic.php?t=2145).

## Screenshot
<img width="1198" alt="Screen Shot 2021-12-13 at 8 28 42 PM" src="https://user-images.githubusercontent.com/33022876/145826301-f564ab87-2a78-4829-b3f0-b3854480d533.png">

## Step to reproduce
Clone this repo and try to install it.
However, the one from Bludit domain is working fine `https://www.bludit.com/releases/bludit-3-13-1.zip`.

## Environment
Tested on MacOS, Nginx.
