### PR TITLE
Add select type in custom fields

### DIFF
--- a/bl-kernel/admin/views/edit-content.php
+++ b/bl-kernel/admin/views/edit-content.php
@@ -389,6 +389,18 @@ echo Bootstrap::formOpen(array(
 					'class'=>'mb-2',
 					'labelClass'=>'mb-2 pb-2 border-bottom text-uppercase w-100'
 				));
+			} elseif ($options['type']=="select") {
+				if (isset($options['options']) ){
+					$options['options'] = explode(',',','.$options['options']);
+				}
+				echo Bootstrap::formSelect(array(
+		            'name'=>'custom['.$field.']',
+		            'label'=>(isset($options['label'])?$options['label']:''),
+		            'options'=>((isset($options['options']))?$options['options']:''),
+		            'selected'=>$page->custom($field),
+		            'class'=>'mb-2',
+		            'tip'=>(isset($options['tips'])?$options['tips']:''),
+		        ));
 			}
 		}
 	}
@@ -428,6 +440,18 @@ echo Bootstrap::formOpen(array(
 					'class'=>'mt-2',
 					'labelClass'=>'mb-2 pb-2 border-bottom text-uppercase w-100'
 				));
+			} elseif ($options['type']=="select") {
+				if (isset($options['options']) ){
+					$options['options'] = explode(',',','.$options['options']);
+				}
+				echo Bootstrap::formSelect(array(
+		            'name'=>'custom['.$field.']',
+		            'label'=>(isset($options['label'])?$options['label']:''),
+		            'options'=>((isset($options['options']))?$options['options']:''),
+		            'selected'=>$page->custom($field),
+		            'class'=>'mb-2',
+		            'tip'=>(isset($options['tips'])?$options['tips']:''),
+		        ));
 			}
 		}
 	}
@@ -476,11 +500,6 @@ $(document).ready(function() {
 	if (typeof editorInsertMedia != "function") {
 		window.editorInsertMedia = function(filename){
 			$("#jseditor").val($('#jseditor').val()+'<img src="'+filename+'" alt="">');
-		};
-	}
-	if (typeof editorInsertLinkedMedia != "function") {
-		window.editorInsertLinkedMedia = function(filename, link){
-			$("#jseditor").val($('#jseditor').val()+'<a href="'+link+'"><img src="'+filename+'" alt=""></a>');
 		};
 	}
 

--- a/bl-kernel/admin/views/edit-content.php
+++ b/bl-kernel/admin/views/edit-content.php
@@ -502,6 +502,11 @@ $(document).ready(function() {
 			$("#jseditor").val($('#jseditor').val()+'<img src="'+filename+'" alt="">');
 		};
 	}
+	if (typeof editorInsertLinkedMedia != "function") {
+		window.editorInsertLinkedMedia = function(filename, link){
+			$("#jseditor").val($('#jseditor').val()+'<a href="'+link+'"><img src="'+filename+'" alt=""></a>');
+		};
+	}
 
 	// Button switch
 	$("#jsswitchButton").on("click", function() {

--- a/bl-kernel/admin/views/new-content.php
+++ b/bl-kernel/admin/views/new-content.php
@@ -458,6 +458,11 @@ $(document).ready(function() {
 			$("#jseditor").val($('#jseditor').val()+'<img src="'+filename+'" alt="">');
 		};
 	}
+	if (typeof editorInsertLinkedMedia != "function") {
+		window.editorInsertLinkedMedia = function(filename, link){
+			$("#jseditor").val($('#jseditor').val()+'<a href="'+link+'"><img src="'+filename+'" alt=""></a>');
+		};
+	}
 
 	// Button switch
 	$("#jsbuttonSwitch").on("click", function() {

--- a/bl-kernel/admin/views/new-content.php
+++ b/bl-kernel/admin/views/new-content.php
@@ -369,6 +369,18 @@ echo Bootstrap::formOpen(array(
 					'class'=>'mb-2',
 					'labelClass'=>'mb-2 pb-2 border-bottom text-uppercase w-100'
 				));
+			} elseif ($options['type']=="select") {
+				if (isset($options['options']) ){
+					$options['options'] = explode(',',','.$options['options']);
+				}
+				echo Bootstrap::formSelect(array(
+		            'name'=>'custom['.$field.']',
+		            'label'=>(isset($options['label'])?$options['label']:''),
+		            'options'=>((isset($options['options']))?$options['options']:''),
+		            'selected'=>(isset($options['default'])?$options['default']:''),
+		            'class'=>'mb-2',
+		            'tip'=>(isset($options['tips'])?$options['tips']:''),
+		        ));
 			}
 		}
 	}
@@ -409,6 +421,18 @@ echo Bootstrap::formOpen(array(
 					'class'=>'mt-2',
 					'labelClass'=>'mb-2 pb-2 border-bottom text-uppercase w-100'
 				));
+			} elseif ($options['type']=="select") {
+				if (isset($options['options']) ){
+					$options['options'] = explode(',',','.$options['options']);
+				}
+				echo Bootstrap::formSelect(array(
+		            'name'=>'custom['.$field.']',
+		            'label'=>(isset($options['label'])?$options['label']:''),
+		            'options'=>((isset($options['options']))?$options['options']:''),
+		            'selected'=>(isset($options['default'])?$options['default']:''),
+		            'class'=>'mb-2',
+		            'tip'=>(isset($options['tips'])?$options['tips']:''),
+		        ));
 			}
 		}
 	}
@@ -432,11 +456,6 @@ $(document).ready(function() {
 	if (typeof editorInsertMedia != "function") {
 		window.editorInsertMedia = function(filename){
 			$("#jseditor").val($('#jseditor').val()+'<img src="'+filename+'" alt="">');
-		};
-	}
-	if (typeof editorInsertLinkedMedia != "function") {
-		window.editorInsertLinkedMedia = function(filename, link){
-			$("#jseditor").val($('#jseditor').val()+'<a href="'+link+'"><img src="'+filename+'" alt=""></a>');
 		};
 	}
 

--- a/bl-kernel/category.class.php
+++ b/bl-kernel/category.class.php
@@ -15,9 +15,13 @@ class Category {
 			$this->vars['permalink'] 	= DOMAIN_CATEGORIES . $key;
 			$this->vars['list'] 		= $categories->db[$key]['list'];
 		} else {
-			$errorMessage = 'Category not found in database by key ['.$key.']';
-			Log::set(__METHOD__.LOG_SEP.$errorMessage);
-			throw new Exception($errorMessage);
+				$errorMessage = 'Category not found in database by key ['.$key.']';
+				Log::set(__METHOD__.LOG_SEP.$errorMessage);
+				if (DEBUG_MODE === true) {
+					throw new Exception($errorMessage);
+				} else {
+					return false;
+				}
 		}
 	}
 

--- a/bl-kernel/helpers/theme.class.php
+++ b/bl-kernel/helpers/theme.class.php
@@ -234,10 +234,11 @@ class Theme {
 		}
 	}
 
-	public static function favicon($file='favicon.png', $typeIcon='image/png')
+	public static function favicon($file='favicon.png', $typeIcon='image/png', $alternate=false)
 	{
-		return '<link rel="icon" href="'.DOMAIN_THEME.$file.'" type="'.$typeIcon.'">'.PHP_EOL;
+		return '<link rel="'.($alternate ? 'alternate ':'').'icon" href="'.DOMAIN_THEME.$file.'" type="'.$typeIcon.'">'.PHP_EOL;
 	}
+
 
 	public static function keywords($keywords)
 	{

--- a/bl-kernel/pagex.class.php
+++ b/bl-kernel/pagex.class.php
@@ -18,7 +18,11 @@ class Page {
 			if (Text::isEmpty($key) || !$pages->exists($key)) {
 				$errorMessage = 'Page not found in database by key ['.$key.']';
 				Log::set(__METHOD__.LOG_SEP.$errorMessage);
-				throw new Exception($errorMessage);
+				if (DEBUG_MODE === true) {
+					throw new Exception($errorMessage);
+				} else {
+					return false;
+				}
 			}
 			$row = $pages->getPageDB($key);
 		}
@@ -53,7 +57,11 @@ class Page {
 	{
 		$key = $this->key();
 		$filePath = PATH_PAGES.$key.DS.FILENAME;
-		$contentRaw = file_get_contents($filePath);
+		if (is_file($filePath)) {
+			$contentRaw = file_get_contents($filePath);
+		} else {
+			$contentRaw = '';
+		}
 
 		if ($sanitize) {
 			return Sanitize::html($contentRaw);
@@ -281,7 +289,6 @@ class Page {
 		$tmp['tags'] 		= $this->tags(false);
 		$tmp['username'] 	= $this->username();
 		$tmp['category'] 	= $this->category();
-		$tmp['uuid'] 		= $this->uuid();
 		$tmp['dateUTC']		= Date::convertToUTC($this->dateRaw(), DB_DATE_FORMAT, DB_DATE_FORMAT);
 		$tmp['permalink'] 	= $this->permalink(true);
 		$tmp['coverImage'] 		= $this->coverImage(true);

--- a/bl-kernel/pagex.class.php
+++ b/bl-kernel/pagex.class.php
@@ -289,6 +289,7 @@ class Page {
 		$tmp['tags'] 		= $this->tags(false);
 		$tmp['username'] 	= $this->username();
 		$tmp['category'] 	= $this->category();
+		$tmp['uuid'] 		= $this->uuid();
 		$tmp['dateUTC']		= Date::convertToUTC($this->dateRaw(), DB_DATE_FORMAT, DB_DATE_FORMAT);
 		$tmp['permalink'] 	= $this->permalink(true);
 		$tmp['coverImage'] 		= $this->coverImage(true);


### PR DESCRIPTION
1)  Select type in custom fields

I add the select type for custom fields.
Json for this is :
`
    "myfield": {
        "type": "select",
        "label": "My field label",
        "tips": "My field tip",
        "options": "option A,option B,option C",
        "position": "top"
    }`

2) Add possibility to use alternate favicon in theme.class.php helper
3 ) For category and page, error is thrown only in DEBUG_MODE