### PR TITLE
Self Closing Tags

### DIFF
--- a/bl-plugins/canonical/plugin.php
+++ b/bl-plugins/canonical/plugin.php
@@ -4,10 +4,10 @@ class pluginCanonical extends Plugin {
 
 	public function siteHead() {
 		if ($GLOBALS['WHERE_AM_I'] === 'home') {
-			return '<link rel="canonical" href="'.DOMAIN_BASE.'"/>'.PHP_EOL;
+			return '<link rel="canonical" href="'.DOMAIN_BASE.'">'.PHP_EOL;
 		} elseif ($GLOBALS['WHERE_AM_I'] === 'page') {
 			global $page;
-			return '<link rel="canonical" href="'.$page->permalink().'"/>'.PHP_EOL;
+			return '<link rel="canonical" href="'.$page->permalink().'">'.PHP_EOL;
 		}
 	}
 }


### PR DESCRIPTION
Self Closing Tags are discourages according to W3C. Validation shows warning but it's better to not have them. Same is for  <br>