### PR TITLE
Fix #1494

### DIFF
--- a/bl-kernel/admin/views/plugins-settings.php
+++ b/bl-kernel/admin/views/plugins-settings.php
@@ -14,10 +14,19 @@
 			className: className
 		};
 
-		$('input').each(function() {
+		$('input:not([type=checkbox])').each(function() {
 			var key = $(this).attr('name');
 			var value = $(this).val();
 			args[key] = value;
+		});
+
+		$('input[type=checkbox]').each(function() {
+			var key = $(this).attr('name');
+			var value = $(this).val();
+			
+			if($(this).is(":checked")) {
+				args[key] = value;
+			}
 		});
 
 		$('select').each(function() {


### PR DESCRIPTION
Handle `checkbox`different than other `input` elements (such as text, password ...), by using a different selector and check, if the `checkbox` is checked.