### PR TITLE
Logout redirection call must reach the server

### DIFF
--- a/bl-kernel/helpers/redirect.class.php
+++ b/bl-kernel/helpers/redirect.class.php
@@ -24,6 +24,7 @@ class Redirect {
 
 	public static function admin()
 	{
+		header('Cache-Control: no-store');
 		self::url(HTML_PATH_ADMIN_ROOT);
 	}
 }


### PR DESCRIPTION
On Firefox 130 the logout (301 redirection to admin page) is getting cached and hence the logout action does not take place. Adding Cache-control to specify the browser to not-cache this is required for logout to work properly.