### PR TITLE
fix absolute symlink for svg

### DIFF
--- a/bl-kernel/functions.php
+++ b/bl-kernel/functions.php
@@ -933,7 +933,7 @@ function transformImage($file, $imageDir, $thumbnailDir = false)
   // Generate Thumbnail
   if (!empty($thumbnailDir)) {
     if (($fileExtension == 'svg')) {
-      Filesystem::symlink($image, $thumbnailDir . $nextFilename);
+      Filesystem::symlink('..'.DS.$nextFilename, $thumbnailDir . $nextFilename);
     } else {
       $Image = new Image();
       $Image->setImage($image, $site->thumbnailWidth(), $site->thumbnailHeight(), 'crop');


### PR DESCRIPTION
Like in pull request 1530 https://github.com/bludit/bludit/pull/1530 in some cases, like shared hosting, an absolute path within a symlink is not working. Changed it to a relative path.