### PR TITLE
fix: incorrect telegram setting retrieval.

### DIFF
--- a/bl-kernel/user.class.php
+++ b/bl-kernel/user.class.php
@@ -148,7 +148,7 @@ class User
 
 	public function telegram()
 	{
-		return $this->getValue('xing');
+		return $this->getValue('telegram');
 	}
 
 	public function mastodon()


### PR DESCRIPTION
Fixes incorrect getValue call parameter for `telegram()` getter.