### PR TITLE
Fix canoncial links in siteHead plugin

### DIFF
--- a/bl-plugins/canonical/plugin.php
+++ b/bl-plugins/canonical/plugin.php
@@ -5,10 +5,10 @@ class pluginCanonical extends Plugin {
 	public function siteHead()
 	{
 		if ($GLOBALS['WHERE_AM_I'] === 'home') {
-			return '<link rel="canonical" href="'.DOMAIN_BASE.'"/>'.PHP_EOL;
+			return '<link rel="canonical" href="'.DOMAIN_BASE.'">'.PHP_EOL;
 		} elseif ($GLOBALS['WHERE_AM_I'] === 'page') {
 			global $page;
-			return '<link rel="canonical" href="'.$page->permalink().'"/>'.PHP_EOL;
+			return '<link rel="canonical" href="'.$page->permalink().'">'.PHP_EOL;
 		}
 	}
 


### PR DESCRIPTION
Hi, currently the W3C Validator gives the following Info message regarding the currently generated trailing slash on link elements: "Trailing slash on void elements [has no effect](https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements#trailing-slashes-in-void-element-start-tags-do-not-mark-the-start-tags-as-self-closing) and [interacts badly with unquoted attribute values](https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements#trailing-slashes-directly-preceded-by-unquoted-attribute-values)."

The generated code is the following:
```html
<!-- Load Bludit Plugins: Site head -->
<link rel="canonical" href="https://admin.brennt.net/gethomepage-1-0-release-and-new-security-parameter-introduced"/>
```

The trailing (closing) slash is not needed. This PR fixes this.