### PR TITLE
Security Fix: Random Webhook Endpoint Generation

### DIFF
--- a/bl-plugins/remote-content/plugin.php
+++ b/bl-plugins/remote-content/plugin.php
@@ -6,7 +6,7 @@ class pluginRemoteContent extends Plugin
 	public function init()
 	{
 		// Generate a random string for the webhook
-		$randomWebhook = uniqid();
+		$randomWebhook = bin2hex( openssl_random_pseudo_bytes(32) )
 
 		// Key and value for the database of the plugin
 		$this->dbFields = array(


### PR DESCRIPTION
Researched by [John Heyer](https://x.com/hohnjeyer) @ DepthFirst

### Change: Remote Content Webhook Hardening

Replaced the webhook seed generated with uniqid() by a cryptographically secure random value so the webhook path
  can’t be predicted:

```php
// (BEFORE) PREDICTABLE WEBHOOK VALUE
$randomWebhook = uniqid();

// (CURRENT) SECURE WEBHOOK VALUE
$randomWebhook = bin2hex( openssl_random_pseudo_bytes(32) )
```

### Vulnerability Security Impact

- **Unauthenticated Site Takeover**: An attacker who predicts the webhook path triggers beforeAll(), which wipes pages/uploads and replaces them with attacker-controlled content, allowing arbitrary site defacement or malware distribution.

### Vulnerability Details

- **Type**: Predictable Secret / Insufficient Entropy (CWE-330)
- **Affected Component**: bl-plugins/remote-content/plugin.php webhook initializer
- **Root Cause**: Using uniqid() as the sole gating secret; its output closely correlates with activation time, allowing practical brute-force enumeration of the webhook endpoint.

### Residual Risk

Existing webhook values remain weak until regenerated. Administrators should re-save the Remote Content plugin settings (or reinstall the plugin) to issue fresh high-entropy webhooks and ensure old predictable endpoints are retired.

_[Found & Fixed by DepthFirst](https://depthfirst.com/)_