### PR TITLE
Fix bludit not loading

### DIFF
--- a/bl-plugins/remote-content/plugin.php
+++ b/bl-plugins/remote-content/plugin.php
@@ -6,7 +6,7 @@ class pluginRemoteContent extends Plugin
 	public function init()
 	{
 		// Generate a random string for the webhook
-		$randomWebhook = bin2hex( openssl_random_pseudo_bytes(32) )
+		$randomWebhook = bin2hex( openssl_random_pseudo_bytes(32) );
 
 		// Key and value for the database of the plugin
 		$this->dbFields = array(


### PR DESCRIPTION
A semicolon was missing since 86e2c6e88723106cc9f3897774b08e5ea295fce5, causing the whole site to not load.

Fixes #1619