### PR TITLE
chore: add gh action to close inactive issues

### DIFF
--- a/.github/workflows/close_inactive_issues.yml
+++ b/.github/workflows/close_inactive_issues.yml
@@ -10,6 +10,8 @@ jobs:
       - uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
           # The labels you want to PROTECT from being closed
           exempt-issue-labels: 'Bug,New request'
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to manage repository issues: inactive issues are marked stale after 14 days and closed 7 days later, with exemptions for specified labels and custom messages preserved.
  * Workflow explicitly disables PR handling so pull requests are not affected by the inactivity automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->