### PR TITLE
fix: #1637 #1638 fix Search plugin cache errors for tags and categories

### DIFF
--- a/bl-plugins/search/plugin.php
+++ b/bl-plugins/search/plugin.php
@@ -616,16 +616,13 @@ EOF;
 			if ($this->getValue('searchInTags')) {
 				$pageTags = $page->tags(true);
 				if (!empty($pageTags)) {
-					$tagNames = array_map(function($tag) {
-						return $tag->name();
-					}, $pageTags);
-					$cache[$pageKey]['tags'] = implode(' ', $tagNames);
+					$cache[$pageKey]['tags'] = implode(' ', $pageTags);
 				}
 			}
 
 			// Add category if enabled
 			if ($this->getValue('searchInCategories')) {
-				$categoryKey = $page->category();
+				$categoryKey = $page->categoryKey();
 				if (!empty($categoryKey) && isset($categories)) {
 					try {
 						$category = new Category($categoryKey);


### PR DESCRIPTION
tags(true) returns an array of strings, not Tag objects — removed the array_map that called name() on each string. category() returns the display name instead of the database key — switched to categoryKey().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized search plugin cache generation and category handling for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->