### PR TITLE
fix: #1639 use configured numberOfItems instead of hardcoded default in API

### DIFF
--- a/bl-plugins/api/plugin.php
+++ b/bl-plugins/api/plugin.php
@@ -359,7 +359,7 @@ class pluginAPI extends Plugin
 		$scheduled 	= (isset($args['scheduled']) ? $args['scheduled'] == 'true' : false);
 		$untagged 	= (isset($args['untagged']) ? $args['untagged'] == 'true' : false);
 
-		$numberOfItems = (isset($args['numberOfItems']) ? $args['numberOfItems'] : 10);
+		$numberOfItems = (isset($args['numberOfItems']) ? $args['numberOfItems'] : (int)$this->getValue('numberOfItems'));
 		$pageNumber = (isset($args['pageNumber']) ? $args['pageNumber'] : 1);
 		$list = $pages->getList($pageNumber, $numberOfItems, $published, $static, $sticky, $draft, $scheduled);
 


### PR DESCRIPTION
## Summary
- The `getPages()` API endpoint had a hardcoded default of 10 items, ignoring the plugin's configured `numberOfItems` setting
- Now uses the admin-configured value from plugin settings, while still allowing per-request override via the `numberOfItems` query parameter

Closes #1639

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default pagination behavior to respect the plugin's configured settings instead of using a fixed value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->