### PR TITLE
fix: #1643 add setting to enable or disable thumbnail generation

### DIFF
--- a/bl-kernel/admin/views/settings.php
+++ b/bl-kernel/admin/views/settings.php
@@ -467,6 +467,15 @@ echo Bootstrap::formInputHidden(array(
 	<?php
 	echo Bootstrap::formTitle(array('title' => $L->g('Thumbnails')));
 
+	echo Bootstrap::formSelect(array(
+		'name' => 'thumbnailEnable',
+		'label' => $L->g('Thumbnail generation'),
+		'options' => array('true' => $L->g('Enabled'), 'false' => $L->g('Disabled')),
+		'selected' => ($site->thumbnailEnable() ? 'true' : 'false'),
+		'class' => '',
+		'tip' => $L->g('Enable or disable automatic thumbnail generation on image upload.')
+	));
+
 	echo Bootstrap::formInputText(array(
 		'name' => 'thumbnailWidth',
 		'label' => $L->g('Width'),

--- a/bl-kernel/functions.php
+++ b/bl-kernel/functions.php
@@ -968,7 +968,7 @@ function transformImage($file, $imageDir, $thumbnailDir = false)
   chmod($image, 0644);
 
   // Generate Thumbnail
-  if (!empty($thumbnailDir)) {
+  if (!empty($thumbnailDir) && $site->thumbnailEnable()) {
     if (($fileExtension == 'svg')) {
       Filesystem::symlink($image, $thumbnailDir . $nextFilename);
     } else {

--- a/bl-kernel/site.class.php
+++ b/bl-kernel/site.class.php
@@ -46,6 +46,7 @@ class Site extends dbJSON
 		'titleFormatTag' => 	'{{tag-name}} | {{site-title}}',
 		'imageRestrict' =>	true,
 		'imageRelativeToAbsolute' => false,
+		'thumbnailEnable' =>	true,
 		'thumbnailWidth' => 	400, // px
 		'thumbnailHeight' => 	400, // px
 		'thumbnailQuality' => 	100,
@@ -123,6 +124,11 @@ class Site extends dbJSON
 	public function sitemap()
 	{
 		return DOMAIN_BASE . 'sitemap.xml';
+	}
+
+	public function thumbnailEnable()
+	{
+		return $this->getField('thumbnailEnable');
 	}
 
 	public function thumbnailWidth()


### PR DESCRIPTION
## Summary
- Added a new `thumbnailEnable` boolean setting to the site configuration (defaults to `true` for backwards compatibility)
- The toggle is exposed in **Admin panel > Settings > Images** tab, at the top of the Thumbnails section
- When disabled, `transformImage()` skips thumbnail generation entirely

Closes #1643


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added thumbnail generation toggle in the admin Images settings. Users can now enable or disable automatic thumbnail generation, with the feature enabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->