### PR TITLE
TinyMCE plugin: fix typo in French language file

### DIFF
--- a/bl-plugins/tinymce/languages/fr_FR.json
+++ b/bl-plugins/tinymce/languages/fr_FR.json
@@ -2,7 +2,7 @@
 	"plugin-data":
 	{
 		"name": "TinyMCE",
-		"description": "TinyMCE est un éditeur HTML WYSIWYG (What You See Is What You Get) développé en Javascript. Recommandé pour les utilisateurs qui ne sont pas alaise avec le format Markdown."
+		"description": "TinyMCE est un éditeur HTML WYSIWYG (What You See Is What You Get) développé en Javascript. Recommandé pour les utilisateurs qui ne sont pas à l'aise avec le format Markdown."
 	},
 	"toolbar-top": "Barre d'outils supérieure",
 	"toolbar-bottom": "Barre d'outils inférieure",


### PR DESCRIPTION
# Problem
There's a typo in French language file for TinyMCE native Bludit plugin in `plugin-data/description`.

# Solution
Update `description` value from `pas alaise avec` to `pas à l'aise avec`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected spelling and diacritics in French language localization text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->