### PR TITLE
Add a field to manage TinyMCE context menu options

### DIFF
--- a/bl-plugins/tinymce/languages/en.json
+++ b/bl-plugins/tinymce/languages/en.json
@@ -6,6 +6,8 @@
 	},
 	"toolbar-top": "Toolbar top",
 	"toolbar-bottom": "Toolbar bottom",
+	"context-menu": "Context menu",
+	"context-menu-tip": "Empty field to disable the editor’s context menu.",
 	"codesample-languages": "Codesample languages",
 	"codesample-supported-laguages": "Programming languages supported by Prism."
 }

--- a/bl-plugins/tinymce/languages/fr_FR.json
+++ b/bl-plugins/tinymce/languages/fr_FR.json
@@ -6,6 +6,8 @@
 	},
 	"toolbar-top": "Barre d'outils supérieure",
 	"toolbar-bottom": "Barre d'outils inférieure",
+	"context-menu": "Menu contextuel",
+	"context-menu-tip": "Vider le champ pour désactiver le menu contextuel de l'éditeur.",
 	"codesample-languages": "Exemples de codes de langues",
 	"codesample-supported-laguages": "Langages de programmation supportés par Prism."
 }

--- a/bl-plugins/tinymce/plugin.php
+++ b/bl-plugins/tinymce/plugin.php
@@ -13,6 +13,7 @@ class pluginTinymce extends Plugin
 		$this->dbFields = array(
 			'toolbar1' => 'blocks bold italic forecolor backcolor removeformat | bullist numlist table | blockquote alignleft aligncenter alignright | link unlink pagebreak image code',
 			'toolbar2' => '',
+			'contextmenu' => 'link linkchecker image editimage table spellchecker configurepermanentpen',
 			'plugins' => 'code autolink image link pagebreak advlist lists table',
 			'codesampleLanguages' => 'HTML/XML markup|JavaScript javascript|CSS css|PHP php|Ruby ruby|Python python|Java java|C c|C# sharp|C++ cpp'
 		);
@@ -34,6 +35,12 @@ class pluginTinymce extends Plugin
 		$html .= '<div>';
 		$html .= '<label>' . $L->get('toolbar-bottom') . '</label>';
 		$html .= '<input name="toolbar2" id="jstoolbar2" type="text" dir="auto" value="' . $this->getValue('toolbar2') . '">';
+		$html .= '</div>';
+
+		$html .= '<div>';
+		$html .= '<label>' . $L->get('context-menu') . '</label>';
+		$html .= '<input name="contextmenu" id="jscontextmenu" type="text" dir="auto" value="' . $this->getValue('contextmenu') . '">';
+		$html .= '<span class="tip">' . $L->get('context-menu-tip') . '</span>';
 		$html .= '</div>';
 
 		$html .= '<div>';
@@ -76,6 +83,7 @@ class pluginTinymce extends Plugin
 		$toolbar2 = $this->getValue('toolbar2');
 		// Combine toolbars for TinyMCE 6+
 		$toolbar = trim($toolbar1 . ' ' . $toolbar2);
+		$contextmenu = $this->getValue('contextmenu');
 		$content_css = $this->htmlPath() . 'css/tinymce_content.css';
 		$plugins = $this->getValue('plugins');
 		// Convert space-separated plugins to JavaScript array format
@@ -148,6 +156,7 @@ class pluginTinymce extends Plugin
 		plugins: ['$pluginsArray'],
 		toolbar: "$toolbar",
 		language: "$lang",
+		contextmenu: "$contextmenu",
 		content_css: "$content_css",
 		codesample_languages: [$codesampleConfig],
 	});


### PR DESCRIPTION
# Problem
Having context menu in TinyMCE instead of browser's native context menu can be irritating, especially if a user wants to use the browser's spellchecker or any other options.

# Solution
Provide a simple way to add or remove elements from TinyMCE context menu options and the ability to disable it entirely. This is done via a new field in plugin configuration page. Default option list comes from [TinyMCE Context menus documentation](https://www.tiny.cloud/docs/tinymce/latest/contextmenu/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a context menu configuration option for the TinyMCE editor. Administrators can now enable, disable, or customize the editor's context menu through the plugin settings interface.

* **Localization**
  * Added English and French translations for the new context menu configuration feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->