### PR TITLE
Version plugin fix

### DIFF
--- a/bl-plugins/version/plugin.php
+++ b/bl-plugins/version/plugin.php
@@ -39,10 +39,10 @@ class pluginVersion extends Plugin
 		global $L;
 		$html = '';
 		if ($this->getValue('showCurrentVersion')) {
-			$html = '<a id="current-version" class="nav-link" href="' . HTML_PATH_ADMIN_ROOT . 'about' . '">' . $L->get('Version') . ' ' . (defined('BLUDIT_PRO') ? '<span class="bi-heart" style="color: #ffc107"></span>' : '') . '<span class="badge bg-warning rounded-pill">' . BLUDIT_VERSION . '</span></a>';
+			$html = '<a id="current-version" class="current-version nav-link" href="' . HTML_PATH_ADMIN_ROOT . 'about' . '">' . $L->get('Version') . ' ' . (defined('BLUDIT_PRO') ? '<span class="bi-heart" style="color: #ffc107"></span>' : '') . '<span class="badge bg-warning rounded-pill">' . BLUDIT_VERSION . '</span></a>';
 		}
 		if ($this->getValue('newVersionAlert')) {
-			$html .= '<a id="new-version" style="display: none;" target="_blank" href="https://www.bludit.com">' . $L->get('New version available') . ' <span class="bi-bell" style="color: red"></span></a>';
+			$html .= '<a id="new-version" class="new-version" style="display: none;" target="_blank" href="https://www.bludit.com">' . $L->get('New version available') . ' <i class="fa fa-bell text-danger"></i></a>';
 		}
 		return $html;
 	}


### PR DESCRIPTION
# Problem
- there's no information on admin sidebar when a new version is available even when user selected newVersionAlert = true in plugin settings
- bell icon doesn't show either

# Solution
- in js/version.js the `show()` and `hide()` methods act on class selectors, class that the links don't have. I would suggest to add `current-version` and `new-version` class to corresponding links. The other way would be to use `id` selector in the JavaScript file but for this the admin default theme should be refactored because the ids are present twice which prevents the methods to apply (navbar.php and sidebar.php, called in bl-kernel/admin/themes/booty/index.php, are both looping over `$plugins['adminSidebar']`) 
- I would also suggest to get the bell icon from FontAwesome rather than Bootstrap, like for the other nav links icons, and to style it in red via Bootstrap class rather than a style attribute


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated admin sidebar version indicator styling with improved visual distinction for the current version.
  * Replaced icon styling for new version notifications with improved visibility and red highlighting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->