### PR TITLE
Version plugin: correct information in French translation

### DIFF
--- a/bl-plugins/version/languages/fr_FR.json
+++ b/bl-plugins/version/languages/fr_FR.json
@@ -2,7 +2,7 @@
 	"plugin-data":
 	{
 		"name": "Version",
-		"description": "Affiche la version actuelle en bas à droite du panneau d’administration, et vérifie périodiquement les nouvelles versions de Bludit."
+		"description": "Affiche la version actuelle dans la barre latérale du panneau d’administration, et vérifie périodiquement les nouvelles versions de Bludit."
 	},
 	"show-current-version-in-the-sidebar": "Afficher la version actuelle dans la barre latérale",
 	"show-alert-when-there-is-a-new-version-in-the-sidebar": "Afficher une alerte lorsqu'il y a une nouvelle version dans la barre latérale"


### PR DESCRIPTION
# Problem
- in French, plugin description says a link will be added on the lower right hand side of the admin panel

# Solution
- changing from `en bas à droite` (= lower right hand side) to `dans la barre latérale` (= sidebar), which is the expression used in the other plugin language items

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated French translation for the Version plugin in the admin panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->