### PR TITLE
fix: #1506 #1582 #1613 #1571 security and bug fixes

### DIFF
--- a/bl-kernel/functions.php
+++ b/bl-kernel/functions.php
@@ -697,11 +697,18 @@ function editSettings($args)
 function changeUserPassword($args)
 {
   global $users;
+  global $login;
   global $L;
   global $syslog;
 
   // Arguments
   $username = $args['username'];
+
+  // Authorization: only admins or the user themselves can change a password
+  if ($login->role() !== 'admin' && $login->username() !== $username) {
+    Alert::set($L->g('You do not have permissions to access this page'), ALERT_STATUS_FAIL);
+    return false;
+  }
   $newPassword = $args['newPassword'];
   $confirmPassword = $args['confirmPassword'];
 

--- a/bl-kernel/helpers/session.class.php
+++ b/bl-kernel/helpers/session.class.php
@@ -26,11 +26,14 @@ class Session {
             'path' => $path,
             'domain' => $cookieParams["domain"],
             'secure' => $secure,
-            'httponly' => true
+            'httponly' => true,
+            'samesite' => 'Lax'
         ]);
 
 		// Sets the session name to the one set above.
-		session_name(self::$sessionName);
+		// Use the __Secure- prefix when served over HTTPS to prevent cookie hijacking.
+		$sessionName = $secure ? '__Secure-' . self::$sessionName : self::$sessionName;
+		session_name($sessionName);
 
 		// Start session.
 		self::$started = session_start();
@@ -50,10 +53,11 @@ class Session {
 
 	public static function destroy()
 	{
+		$sessionName = session_name();
 		session_destroy();
 		unset($_SESSION);
-		unset($_COOKIE[self::$sessionName]);
-		Cookie::set(self::$sessionName, '', -1);
+		unset($_COOKIE[$sessionName]);
+		Cookie::set($sessionName, '', -1);
 		self::$started = false;
 		Log::set(__METHOD__.LOG_SEP.'Session destroyed.');
 		return !isset($_SESSION);

--- a/bl-kernel/pages.class.php
+++ b/bl-kernel/pages.class.php
@@ -261,7 +261,7 @@ class Pages extends dbJSON
 		}
 
 		// If the content was passed via arguments replace the content
-		if (isset($args['content'])) {
+		if (isset($args['content']) && $args['content'] !== '') {
 			// Make the index.txt and save the file.
 			if (file_put_contents(PATH_PAGES . $newKey . DS . FILENAME, $args['content']) === false) {
 				Log::set(__METHOD__ . LOG_SEP . 'Error occurred when trying to put the content in the file ' . FILENAME);

--- a/bl-languages/en.json
+++ b/bl-languages/en.json
@@ -85,6 +85,7 @@
     "url-associated-with-the-content": "URL associated with the content.",
     "language-and-timezone": "Language and timezone",
     "change-your-language-and-region-settings": "Change your language and region settings.",
+    "Navigation": "Navigation",
     "notifications": "Notifications",
     "plugin-activated": "Plugin activated",
     "plugin-deactivated": "Plugin deactivated",
@@ -403,5 +404,7 @@
     "insert-thumbnail": "Insert thumbnail",
     "insert-linked-thumbnail": "Insert linked thumbnail",
     "no-categories": "No categories",
-    "no-tags": "No tags"
-}
+            "no-tags": "No tags",
+            "thumbnail-generation": "Thumbnail generation",
+            "enable-disable-automatic-thumbnail-generation-on-image-upload": "Enable or disable automatic thumbnail generation on image upload."
+        }

--- a/bl-plugins/navigation/plugin.php
+++ b/bl-plugins/navigation/plugin.php
@@ -61,7 +61,7 @@ class pluginNavigation extends Plugin
 		// Print the label if not empty
 		$label = $this->getValue('label');
 		if (!empty($label)) {
-			$html .= '<h2 class="plugin-label">' . $label . '</h2>';
+			$html .= '<h2 class="plugin-label">' . htmlspecialchars($L->g($label), ENT_QUOTES, 'UTF-8') . '</h2>';
 		}
 
 		$html .= '<div class="plugin-content">';


### PR DESCRIPTION
Fixes #1506, #1582, #1613, #1571

- **#1506** — IDOR in `changeUserPassword()`: added authorization check so only admins or the user themselves can change a password
- **#1582** — Session cookie security: added `SameSite=Lax` and `__Secure-` prefix when served over HTTPS
- **#1613** — Page content erased on edit: skip `file_put_contents` when content is empty
- **#1571** — Navigation sidebar label: escape output with `htmlspecialchars` and localize via `$L->g()`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Bug Fixes**
  * Enhanced password change authorization—only admins or account owners can modify passwords
  * Improved session cookie security with additional protective attributes
  * Fixed potential HTML injection vulnerability in navigation sidebar
  * Prevented accidental content overwrites with empty values

* **Localization**
  * Added new UI text strings for navigation and thumbnail generation features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->