### PR TITLE
Ensure that the search term and search URL are html escaped

### DIFF
--- a/bl-plugins/canonical/plugin.php
+++ b/bl-plugins/canonical/plugin.php
@@ -53,7 +53,7 @@ class pluginCanonical extends Plugin {
 		}
 
 		if (!empty($canonical)) {
-			$html .= '<link rel="canonical" href="' . $canonical . '">' . PHP_EOL;
+			$html .= '<link rel="canonical" href="' . htmlspecialchars($canonical, ENT_QUOTES, 'UTF-8') . '">' . PHP_EOL;
 
 			// Add prev/next for paginated content (helps search engines)
 			$pageNumber = $url->pageNumber();
@@ -64,7 +64,7 @@ class pluginCanonical extends Plugin {
 				} else {
 					$prevUrl = preg_replace('/page\/\d+\/?$/', 'page/' . ($pageNumber - 1) . '/', $canonical);
 				}
-				$html .= '<link rel="prev" href="' . $prevUrl . '">' . PHP_EOL;
+				$html .= '<link rel="prev" href="' . htmlspecialchars($prevUrl, ENT_QUOTES, 'UTF-8') . '">' . PHP_EOL;
 			}
 
 			// Next page (only if more content exists)
@@ -78,7 +78,7 @@ class pluginCanonical extends Plugin {
 				} else {
 					$nextUrl = preg_replace('/page\/\d+\/?$/', 'page/' . ($pageNumber + 1) . '/', $canonical);
 				}
-				$html .= '<link rel="next" href="' . $nextUrl . '">' . PHP_EOL;
+				$html .= '<link rel="next" href="' . htmlspecialchars($nextUrl, ENT_QUOTES, 'UTF-8') . '">' . PHP_EOL;
 			}
 		}
 

--- a/bl-themes/alternative/php/home.php
+++ b/bl-themes/alternative/php/home.php
@@ -30,7 +30,7 @@
 									<circle cx="11" cy="11" r="8"></circle>
 									<path d="M21 21l-4.35-4.35"></path>
 								</svg>
-								<input id="search-input" class="form-control" type="search" placeholder="<?php $language->p('Search') ?>" aria-label="<?php $language->p('Search') ?>" value="<?php echo ($WHERE_AM_I==='search'?$searchPlugin->getSearchTerm():'') ?>">
+								<input id="search-input" class="form-control" type="search" placeholder="<?php $language->p('Search') ?>" aria-label="<?php $language->p('Search') ?>" value="<?php echo ($WHERE_AM_I==='search'?htmlspecialchars($searchPlugin->getSearchTerm(), ENT_QUOTES, 'UTF-8'):'') ?>">
 							</div>
 						</form>
 					</div>
@@ -143,7 +143,7 @@
 			<!-- Previous button -->
 			<?php if (Paginator::showPrev()) : ?>
 				<li class="page-item mr-2">
-					<a class="page-link" href="<?php echo Paginator::previousPageUrl() ?>" rel="prev" aria-label="<?php echo $L->get('Previous'); ?>">
+					<a class="page-link" href="<?php echo htmlspecialchars(Paginator::previousPageUrl(), ENT_QUOTES, 'UTF-8') ?>" rel="prev" aria-label="<?php echo $L->get('Previous'); ?>">
 						<span aria-hidden="true">&#9664;</span> <?php echo $L->get('Previous'); ?>
 					</a>
 				</li>
@@ -157,7 +157,7 @@
 			<!-- Next button -->
 			<?php if (Paginator::showNext()) : ?>
 				<li class="page-item ml-2">
-					<a class="page-link" href="<?php echo Paginator::nextPageUrl() ?>" rel="next" aria-label="<?php echo $L->get('Next'); ?>">
+					<a class="page-link" href="<?php echo htmlspecialchars(Paginator::nextPageUrl(), ENT_QUOTES, 'UTF-8') ?>" rel="next" aria-label="<?php echo $L->get('Next'); ?>">
 						<?php echo $L->get('Next'); ?> <span aria-hidden="true">&#9658;</span>
 					</a>
 				</li>

--- a/bl-themes/blogx/php/home.php
+++ b/bl-themes/blogx/php/home.php
@@ -72,7 +72,7 @@
       <!-- Previous button -->
       <?php if (Paginator::showPrev()) : ?>
         <li class="page-item mr-2">
-          <a class="page-link" href="<?php echo Paginator::previousPageUrl() ?>" tabindex="-1">
+          <a class="page-link" href="<?php echo htmlspecialchars(Paginator::previousPageUrl(), ENT_QUOTES, 'UTF-8') ?>" tabindex="-1">
             <i class="bi bi-chevron-left"></i> <?php echo $L->get('Previous'); ?>
           </a>
         </li>
@@ -88,7 +88,7 @@
       <!-- Next button -->
       <?php if (Paginator::showNext()) : ?>
         <li class="page-item ml-2">
-          <a class="page-link" href="<?php echo Paginator::nextPageUrl() ?>">
+          <a class="page-link" href="<?php echo htmlspecialchars(Paginator::nextPageUrl(), ENT_QUOTES, 'UTF-8') ?>">
             <?php echo $L->get('Next'); ?> <i class="bi bi-chevron-right"></i>
           </a>
         </li>

--- a/bl-themes/flavor/php/home.php
+++ b/bl-themes/flavor/php/home.php
@@ -74,14 +74,14 @@
 <nav class="flex justify-between items-center py-8 border-t border-gray-200 dark:border-gray-800">
 	<div>
 		<?php if (Paginator::showPrev()) : ?>
-		<a href="<?php echo Paginator::previousPageUrl() ?>" class="inline-flex items-center text-sm font-medium text-accent-600 dark:text-accent-400 hover:text-accent-700 dark:hover:text-accent-300 no-underline transition-colors">
+		<a href="<?php echo htmlspecialchars(Paginator::previousPageUrl(), ENT_QUOTES, 'UTF-8') ?>" class="inline-flex items-center text-sm font-medium text-accent-600 dark:text-accent-400 hover:text-accent-700 dark:hover:text-accent-300 no-underline transition-colors">
 			&larr; <?php echo $L->get('Previous'); ?>
 		</a>
 		<?php endif; ?>
 	</div>
 	<div>
 		<?php if (Paginator::showNext()) : ?>
-		<a href="<?php echo Paginator::nextPageUrl() ?>" class="inline-flex items-center text-sm font-medium text-accent-600 dark:text-accent-400 hover:text-accent-700 dark:hover:text-accent-300 no-underline transition-colors">
+		<a href="<?php echo htmlspecialchars(Paginator::nextPageUrl(), ENT_QUOTES, 'UTF-8') ?>" class="inline-flex items-center text-sm font-medium text-accent-600 dark:text-accent-400 hover:text-accent-700 dark:hover:text-accent-300 no-underline transition-colors">
 			<?php echo $L->get('Next'); ?> &rarr;
 		</a>
 		<?php endif; ?>

--- a/bl-themes/popeye/php/home.php
+++ b/bl-themes/popeye/php/home.php
@@ -130,7 +130,7 @@
 							<!-- Older pages -->
 							<?php if (Paginator::showNext()) : ?>
 								<li class="page-item">
-									<a class="page-link" href="<?php echo Paginator::nextPageUrl() ?>">&#9664; <?php echo $L->get('Previous'); ?></a>
+									<a class="page-link" href="<?php echo htmlspecialchars(Paginator::nextPageUrl(), ENT_QUOTES, 'UTF-8') ?>">&#9664; <?php echo $L->get('Previous'); ?></a>
 								</li>
 							<?php endif; ?>
 							<!-- End Older pages -->
@@ -138,7 +138,7 @@
 							<!-- Newer pages -->
 							<?php if (Paginator::showPrev()) : ?>
 								<li class="page-item ml-auto">
-									<a class="page-link" href="<?php echo Paginator::previousPageUrl() ?>" tabindex="-1"><?php echo $L->get('Next'); ?> &#9658;</a>
+									<a class="page-link" href="<?php echo htmlspecialchars(Paginator::previousPageUrl(), ENT_QUOTES, 'UTF-8') ?>" tabindex="-1"><?php echo $L->get('Next'); ?> &#9658;</a>
 								</li>
 							<?php endif; ?>
 							<!-- End Newer pages -->


### PR DESCRIPTION
This change fixes (I think) the problem raised in #1681. The search term needs to be html-escaped  when it is displayed directly and also when included in a URL such as canonical URL and the previous/next URLs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering of URLs with special characters in canonical links, pagination navigation, and search input values across multiple themes and the canonical plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->