### PR TITLE
fix: media manager wrong extensions and ghost thumbnails on delete (#1694)

### DIFF
--- a/bl-kernel/admin/themes/booty/html/media.php
+++ b/bl-kernel/admin/themes/booty/html/media.php
@@ -1,13 +1,16 @@
 <?php
-// Preload the first 10 files to not call via AJAX when the user open the first time the media manager
-$listOfFilesByPage = Filesystem::listFiles(PAGE_THUMBNAILS_DIRECTORY, '*', '*', MEDIA_MANAGER_SORT_BY_DATE, MEDIA_MANAGER_NUMBER_OF_FILES);
-$preLoadFiles = array();
-if (!empty($listOfFilesByPage[0])) {
-	foreach ($listOfFilesByPage[0] as $file) {
-		$filename = Filesystem::filename($file);
-		array_push($preLoadFiles, $filename);
-	}
+// Preload the first chunk of files to avoid an AJAX round-trip the first time
+// the Media Manager is opened. Scans originals and resolves each thumbnail,
+// mirroring the shape returned by ajax/list-images.
+if (IMAGE_RESTRICT) {
+	$mediaImagesPath = PATH_UPLOADS_PAGES.PAGE_IMAGES_KEY.DS;
+	$mediaThumbnailsPath = PATH_UPLOADS_PAGES.PAGE_IMAGES_KEY.DS.'thumbnails'.DS;
+} else {
+	$mediaImagesPath = PATH_UPLOADS;
+	$mediaThumbnailsPath = PATH_UPLOADS_THUMBNAILS;
 }
+$listOfFilesByPage = mediaManagerListImages($mediaImagesPath, $mediaThumbnailsPath, MEDIA_MANAGER_NUMBER_OF_FILES);
+$preLoadFiles = !empty($listOfFilesByPage[0]) ? $listOfFilesByPage[0] : array();
 
 // Amount of pages for the paginator
 $numberOfPages = count($listOfFilesByPage);
@@ -98,8 +101,9 @@ function displayFiles(files, numberOfPages = <?= $numberOfPages ?>) {
 
 	// Regenerate the table
 	if (files.length > 0) {
-		$.each(files, function(key, filename) {
-			var thumbnail = "<?php echo PAGE_THUMBNAILS_URL; ?>"+filename;
+		$.each(files, function(key, item) {
+			var filename = item.filename;
+			var thumbnail = "<?php echo PAGE_THUMBNAILS_URL; ?>"+item.thumbnail;
 			var image = "<?php echo PAGE_IMAGES_URL; ?>"+filename;
 
 			tableRow = '<tr id="js'+filename+'">'+

--- a/bl-kernel/admin/themes/booty/html/media.php
+++ b/bl-kernel/admin/themes/booty/html/media.php
@@ -103,8 +103,11 @@ function displayFiles(files, numberOfPages = <?= $numberOfPages ?>) {
 	if (files.length > 0) {
 		$.each(files, function(key, item) {
 			var filename = item.filename;
-			var thumbnail = "<?php echo PAGE_THUMBNAILS_URL; ?>"+item.thumbnail;
 			var image = "<?php echo PAGE_IMAGES_URL; ?>"+filename;
+			// item.thumbnail is empty when no thumbnail file exists (thumbnails
+			// disabled, generation failed, format unsupported by GD). Fall back
+			// to the original image so the preview never 404s.
+			var thumbnail = item.thumbnail ? "<?php echo PAGE_THUMBNAILS_URL; ?>"+item.thumbnail : image;
 
 			tableRow = '<tr id="js'+filename+'">'+
 					'<td style="width:80px"><img class="img-thumbnail" alt="200x200" src="'+thumbnail+'" style="width: 50px; height: 50px;"><\/td>'+

--- a/bl-kernel/ajax/delete-image.php
+++ b/bl-kernel/ajax/delete-image.php
@@ -21,6 +21,9 @@ if ($filename===false) {
 }
 
 if ($uuid && IMAGE_RESTRICT) {
+	if (Text::stringContains($uuid, DS, false)) {
+		ajaxResponse(1, 'Invalid uuid.');
+	}
 	$imagePath = PATH_UPLOADS_PAGES.$uuid.DS;
 	$thumbnailPath = PATH_UPLOADS_PAGES.$uuid.DS.'thumbnails'.DS;
 } else {
@@ -28,14 +31,33 @@ if ($uuid && IMAGE_RESTRICT) {
 	$thumbnailPath = PATH_UPLOADS_THUMBNAILS;
 }
 
-// Delete image
+// Delete the original
 if (Sanitize::pathFile($imagePath.$filename)) {
 	Filesystem::rmfile($imagePath.$filename);
 }
 
-// Delete thumbnail
-if (Sanitize::pathFile($thumbnailPath.$filename)) {
+// Delete the thumbnail. Exact-name match is the fast path (new uploads have
+// matching extensions). If no exact match, fall back to any allowed-extension
+// match on the basename — this recovers legacy pairs where thumbnails were
+// forced to .jpg while the original kept its real extension. Before deleting
+// a mismatched candidate, verify no other original owns that extension, to
+// avoid taking out an unrelated image's thumbnail.
+if (Sanitize::pathFile($thumbnailPath.$filename) && is_file($thumbnailPath.$filename)) {
 	Filesystem::rmfile($thumbnailPath.$filename);
+} else {
+	$base = pathinfo($filename, PATHINFO_FILENAME);
+	foreach ($GLOBALS['ALLOWED_IMG_EXTENSION'] as $ext) {
+		$candidate = $base.'.'.$ext;
+		if ($candidate === $filename) {
+			continue;
+		}
+		if (is_file($imagePath.$candidate)) {
+			continue;
+		}
+		if (Sanitize::pathFile($thumbnailPath.$candidate) && is_file($thumbnailPath.$candidate)) {
+			Filesystem::rmfile($thumbnailPath.$candidate);
+		}
+	}
 }
 
 ajaxResponse(0, 'Image deleted.');

--- a/bl-kernel/ajax/list-images.php
+++ b/bl-kernel/ajax/list-images.php
@@ -8,7 +8,10 @@ header('Content-Type: application/json');
 | @_POST['path']	string	Pre-defined name for the directory to read, its pre-defined to avoid security issues
 | @_POST['uuid']	string	Page UUID
 |
-| @return	array
+| @return	array	Each file is an object with 'filename' (original) and
+|			'thumbnail' (resolved preview filename — may differ from
+|			the original for legacy pairs or fall back to it when no
+|			thumbnail exists).
 */
 
 // $_POST
@@ -21,36 +24,31 @@ $path = empty($_POST['path']) ? false : $_POST['path'];
 $uuid = empty($_POST['uuid']) ? false : $_POST['uuid'];
 // ----------------------------------------------------------------------------
 
-// Set the path to get the file list
-if ($path=='thumbnails') {
-	if ($uuid && IMAGE_RESTRICT) {
-		$path = PATH_UPLOADS_PAGES.$uuid.DS.'thumbnails'.DS;
-	} else {
-		$path = PATH_UPLOADS_THUMBNAILS;
-	}
-} else {
+// The only accepted value is kept for backward-compat with clients that
+// preserve the old contract; the server now scans originals regardless.
+if ($path !== 'thumbnails') {
 	ajaxResponse(1, 'Invalid path.');
 }
 
-// Get all files from the directory $path, also split the array by numberOfItems
-// The function listFiles split in chunks
-$listOfFilesByPage = Filesystem::listFiles($path, '*', '*', MEDIA_MANAGER_SORT_BY_DATE, MEDIA_MANAGER_NUMBER_OF_FILES);
-
-// Check if the page number exists in the chunks
-if (isset($listOfFilesByPage[$pageNumber])) {
-
-	// Get only the filename from the chunk
-	$files = array();
-	foreach ($listOfFilesByPage[$pageNumber] as $file) {
-		$filename = basename($file);
-		array_push($files, $filename);
+// Resolve the originals and thumbnails directories
+if ($uuid && IMAGE_RESTRICT) {
+	if (Text::stringContains($uuid, DS, false)) {
+		ajaxResponse(1, 'Invalid uuid.');
 	}
+	$imagePath = PATH_UPLOADS_PAGES.$uuid.DS;
+	$thumbnailPath = PATH_UPLOADS_PAGES.$uuid.DS.'thumbnails'.DS;
+} else {
+	$imagePath = PATH_UPLOADS;
+	$thumbnailPath = PATH_UPLOADS_THUMBNAILS;
+}
 
-	// Returns the number of chunks for the paginator
-	// Returns the files inside the chunk
+// Scan originals and pair each with its matching thumbnail
+$listOfFilesByPage = mediaManagerListImages($imagePath, $thumbnailPath, MEDIA_MANAGER_NUMBER_OF_FILES);
+
+if (isset($listOfFilesByPage[$pageNumber])) {
 	ajaxResponse(0, 'List of files and number of chunks.', array(
 		'numberOfPages'=>count($listOfFilesByPage),
-		'files'=>$files
+		'files'=>$listOfFilesByPage[$pageNumber]
 	));
 }
 

--- a/bl-kernel/ajax/profile-picture-upload.php
+++ b/bl-kernel/ajax/profile-picture-upload.php
@@ -82,7 +82,12 @@ if (!$moved) {
 
 // Resize and convert to png
 $image = new Image();
-$image->setImage(PATH_TMP.$tmpFilename, PROFILE_IMG_WIDTH, PROFILE_IMG_HEIGHT, 'crop');
+if ($image->setImage(PATH_TMP.$tmpFilename, PROFILE_IMG_WIDTH, PROFILE_IMG_HEIGHT, 'crop') === false) {
+	Filesystem::rmfile(PATH_TMP.$tmpFilename);
+	$message = 'Profile picture upload failed: GD cannot decode the image (unsupported format or corrupted file).';
+	Log::set($message, LOG_TYPE_ERROR);
+	ajaxResponse(1, $message);
+}
 $image->saveImage(PATH_UPLOADS_PROFILES.$filename, PROFILE_IMG_QUALITY, false, true);
 
 // Delete temporary file

--- a/bl-kernel/functions.php
+++ b/bl-kernel/functions.php
@@ -1056,20 +1056,23 @@ function mediaManagerListImages($imagePath, $thumbnailPath, $chunk)
         continue;
       }
 
-      // Resolve thumbnail. Fast path: same filename. Fallback: allowed-extension
-      // match by basename to cover legacy pairs. If neither exists, return an
-      // empty string so the client can fall back to the original image URL.
+      // Resolve thumbnail. Fast path: same filename. Legacy fallback: before
+      // commit 82f30f8b thumbnails were forced to .jpg, so try that single
+      // extension when the fast path misses. Only accept the .jpg candidate
+      // when it does not exist as an independent original (i.e. it is truly a
+      // legacy thumbnail, not another file's own thumbnail). If nothing matches,
+      // return an empty string so the client falls back to the original URL.
       $thumbnail = '';
       if (is_file($thumbnailPath . $filename)) {
         $thumbnail = $filename;
       } else {
         $base = pathinfo($filename, PATHINFO_FILENAME);
-        foreach ($GLOBALS['ALLOWED_IMG_EXTENSION'] as $ext) {
-          $candidate = $base . '.' . $ext;
-          if ($candidate !== $filename && is_file($thumbnailPath . $candidate)) {
-            $thumbnail = $candidate;
-            break;
-          }
+        $candidate = $base . '.jpg';
+        if ($candidate !== $filename
+          && is_file($thumbnailPath . $candidate)
+          && !is_file($imagePath . $candidate)
+        ) {
+          $thumbnail = $candidate;
         }
       }
 

--- a/bl-kernel/functions.php
+++ b/bl-kernel/functions.php
@@ -1012,8 +1012,10 @@ function transformImage($file, $imageDir, $thumbnailDir = false)
 |  - Legacy uploads: before commit 82f30f8b thumbnails were forced to .jpg, so
 |    pre-existing pairs may have different extensions (e.g., original test.png
 |    with thumbnail test.jpg).
-|  - Thumbnail generation disabled or failed: no thumbnail exists at all; the
-|    original is returned as its own thumbnail so the item still renders.
+|  - Thumbnail generation disabled or failed: no thumbnail file exists at all.
+|    In that case 'thumbnail' is returned as an empty string so the client can
+|    fall back to the original image URL instead of building a broken
+|    PAGE_THUMBNAILS_URL + filename that would 404.
 |
 | @imagePath     string  Filesystem path to the originals directory (trailing DS)
 | @thumbnailPath string  Filesystem path to the thumbnails directory (trailing DS)
@@ -1024,6 +1026,8 @@ function transformImage($file, $imageDir, $thumbnailDir = false)
 */
 function mediaManagerListImages($imagePath, $thumbnailPath, $chunk)
 {
+  global $site;
+
   // Filesystem::listFiles globs '*.*' which does not match the 'thumbnails'
   // subdirectory (no dot in the name), so scanning the originals directory
   // naturally skips it.
@@ -1032,6 +1036,11 @@ function mediaManagerListImages($imagePath, $thumbnailPath, $chunk)
     return array();
   }
 
+  // The site logo is stored in PATH_UPLOADS (not in a per-page directory)
+  // alongside uploaded images when IMAGE_RESTRICT is off. Exclude it from the
+  // Media Manager listing so it cannot be inserted/deleted as a media file.
+  $logoFilename = ($site && method_exists($site, 'logo')) ? $site->logo(false) : '';
+
   foreach ($chunks as $i => $chunkFiles) {
     $items = array();
     foreach ($chunkFiles as $file) {
@@ -1039,16 +1048,21 @@ function mediaManagerListImages($imagePath, $thumbnailPath, $chunk)
         continue;
       }
       $filename = basename($file);
+      if ($logoFilename && $filename === $logoFilename) {
+        continue;
+      }
       $extension = Text::lowercase(pathinfo($filename, PATHINFO_EXTENSION));
       if (!in_array($extension, $GLOBALS['ALLOWED_IMG_EXTENSION'])) {
         continue;
       }
 
       // Resolve thumbnail. Fast path: same filename. Fallback: allowed-extension
-      // match by basename to cover legacy pairs. Final fallback: the original
-      // itself, so the Media Manager never renders a broken image.
-      $thumbnail = $filename;
-      if (!is_file($thumbnailPath . $filename)) {
+      // match by basename to cover legacy pairs. If neither exists, return an
+      // empty string so the client can fall back to the original image URL.
+      $thumbnail = '';
+      if (is_file($thumbnailPath . $filename)) {
+        $thumbnail = $filename;
+      } else {
         $base = pathinfo($filename, PATHINFO_FILENAME);
         foreach ($GLOBALS['ALLOWED_IMG_EXTENSION'] as $ext) {
           $candidate = $base . '.' . $ext;

--- a/bl-kernel/functions.php
+++ b/bl-kernel/functions.php
@@ -988,12 +988,86 @@ function transformImage($file, $imageDir, $thumbnailDir = false)
       Filesystem::symlink($image, $thumbnailDir . $nextFilename);
     } else {
       $Image = new Image();
-      $Image->setImage($image, $site->thumbnailWidth(), $site->thumbnailHeight(), 'crop');
-      $Image->saveImage($thumbnailDir . $nextFilename, $site->thumbnailQuality());
+      // setImage() returns false when GD cannot decode the source (missing
+      // format support or corrupted file). Skip saveImage() in that case and
+      // log so the operator can diagnose — the original image remains stored
+      // so the Media Manager can still display it via the fallback path.
+      if ($Image->setImage($image, $site->thumbnailWidth(), $site->thumbnailHeight(), 'crop') === false) {
+        Log::set('Thumbnail generation skipped (GD cannot decode): ' . $image, LOG_TYPE_ERROR);
+      } else {
+        $Image->saveImage($thumbnailDir . $nextFilename, $site->thumbnailQuality());
+      }
     }
   }
 
   return $image;
+}
+
+/*
+| Builds the file list for the Media Manager. Scans originals (not thumbnails)
+| and pairs each original with its matching thumbnail. Used by list-images.php
+| and the Media Manager preload in media.php.
+|
+| The thumbnail filename usually matches the original, but can differ:
+|  - Legacy uploads: before commit 82f30f8b thumbnails were forced to .jpg, so
+|    pre-existing pairs may have different extensions (e.g., original test.png
+|    with thumbnail test.jpg).
+|  - Thumbnail generation disabled or failed: no thumbnail exists at all; the
+|    original is returned as its own thumbnail so the item still renders.
+|
+| @imagePath     string  Filesystem path to the originals directory (trailing DS)
+| @thumbnailPath string  Filesystem path to the thumbnails directory (trailing DS)
+| @chunk         int     Chunk size for pagination
+|
+| @return array[]  Array of chunks; each chunk is an array of items with keys
+|                  'filename' (original) and 'thumbnail' (resolved preview).
+*/
+function mediaManagerListImages($imagePath, $thumbnailPath, $chunk)
+{
+  // Filesystem::listFiles globs '*.*' which does not match the 'thumbnails'
+  // subdirectory (no dot in the name), so scanning the originals directory
+  // naturally skips it.
+  $chunks = Filesystem::listFiles($imagePath, '*', '*', MEDIA_MANAGER_SORT_BY_DATE, $chunk);
+  if (empty($chunks)) {
+    return array();
+  }
+
+  foreach ($chunks as $i => $chunkFiles) {
+    $items = array();
+    foreach ($chunkFiles as $file) {
+      if (is_dir($file)) {
+        continue;
+      }
+      $filename = basename($file);
+      $extension = Text::lowercase(pathinfo($filename, PATHINFO_EXTENSION));
+      if (!in_array($extension, $GLOBALS['ALLOWED_IMG_EXTENSION'])) {
+        continue;
+      }
+
+      // Resolve thumbnail. Fast path: same filename. Fallback: allowed-extension
+      // match by basename to cover legacy pairs. Final fallback: the original
+      // itself, so the Media Manager never renders a broken image.
+      $thumbnail = $filename;
+      if (!is_file($thumbnailPath . $filename)) {
+        $base = pathinfo($filename, PATHINFO_FILENAME);
+        foreach ($GLOBALS['ALLOWED_IMG_EXTENSION'] as $ext) {
+          $candidate = $base . '.' . $ext;
+          if ($candidate !== $filename && is_file($thumbnailPath . $candidate)) {
+            $thumbnail = $candidate;
+            break;
+          }
+        }
+      }
+
+      $items[] = array(
+        'filename' => $filename,
+        'thumbnail' => $thumbnail,
+      );
+    }
+    $chunks[$i] = $items;
+  }
+
+  return $chunks;
 }
 
 function downloadRestrictedFile($file)

--- a/bl-kernel/helpers/image.class.php
+++ b/bl-kernel/helpers/image.class.php
@@ -87,19 +87,36 @@ class Image {
         // *** Get extension
         $extension = strtolower(strrchr($file, '.'));
 
+        // GD may be compiled without support for some formats (often WebP, and
+        // sometimes JPEG on minimal builds). Guard each decoder with both a
+        // runtime capability check and a function_exists() check to avoid a
+        // fatal "call to undefined function" on stripped builds.
+        $types = imagetypes();
         switch($extension)
         {
             case '.jpg':
             case '.jpeg':
+                if (!($types & IMG_JPG) || !function_exists('imagecreatefromjpeg')) {
+                    return false;
+                }
                 $img = imagecreatefromjpeg($file);
                 break;
             case '.gif':
+                if (!($types & IMG_GIF) || !function_exists('imagecreatefromgif')) {
+                    return false;
+                }
                 $img = imagecreatefromgif($file);
                 break;
             case '.png':
+                if (!($types & IMG_PNG) || !function_exists('imagecreatefrompng')) {
+                    return false;
+                }
                 $img = imagecreatefrompng($file);
                 break;
             case '.webp':
+                if (!($types & IMG_WEBP) || !function_exists('imagecreatefromwebp')) {
+                    return false;
+                }
                 $img = imagecreatefromwebp($file);
                 break;
             default:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stronger path validation to prevent path traversal and unauthorized file access.
  * Safer thumbnail deletion with controlled legacy handling to avoid removing unrelated files.
  * More robust image decoding checks with clear failure handling for uploads and thumbnail creation.

* **Improvements**
  * Media listings and initial preload now return consistent item objects pairing originals and thumbnails.
  * Client-side previews fall back to originals when thumbnails are missing, preventing broken previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->