### PR TITLE
chore: bump version to 3.21.0

### DIFF
--- a/bl-kernel/admin/themes/booty/css/bludit.bootstrap.css
+++ b/bl-kernel/admin/themes/booty/css/bludit.bootstrap.css
@@ -122,7 +122,7 @@ a.text-danger:hover {
 }
 
 .form-control:focus {
-	border-color: var(--primary-blue, #0078D4);
+	border-color: #b0bec5;
 }
 
 label {

--- a/bl-kernel/admin/themes/booty/css/bludit.bootstrap.css
+++ b/bl-kernel/admin/themes/booty/css/bludit.bootstrap.css
@@ -121,10 +121,6 @@ a.text-danger:hover {
 	transition: all 0.2s ease;
 }
 
-.form-control:focus {
-	border-color: #b0bec5;
-}
-
 label {
 	font-weight: var(--font-weight-semibold, 650);
 	color: var(--text-primary, #0F172A);

--- a/bl-kernel/admin/themes/booty/css/bludit.css
+++ b/bl-kernel/admin/themes/booty/css/bludit.css
@@ -787,13 +787,14 @@ img.profilePicture {
 	color: #1cb11c;
 }
 
-/* Remove focus glow (box-shadow) from all form elements but keep the blue border */
+/* Subtle focus style for form elements */
 input:focus,
 textarea:focus,
 select:focus,
 .form-control:focus,
 .custom-select:focus,
 .btn:focus {
-	border-color: #016DE7 !important;
+	border-color: #b0bec5 !important;
 	box-shadow: none !important;
+	outline: none !important;
 }

--- a/bl-kernel/boot/init.php
+++ b/bl-kernel/boot/init.php
@@ -1,10 +1,10 @@
 <?php defined('BLUDIT') or die('Bludit CMS.');
 
 // Bludit version
-define('BLUDIT_VERSION',        '3.20.0');
-define('BLUDIT_CODENAME',       'LoboIberico');
-define('BLUDIT_RELEASE_DATE',   '2026-04-09');
-define('BLUDIT_BUILD',          '20260409');
+define('BLUDIT_VERSION',        '3.21.0');
+define('BLUDIT_CODENAME',       'ImperialEagle');
+define('BLUDIT_RELEASE_DATE',   '2026-04-25');
+define('BLUDIT_BUILD',          '20260425');
 
 // Change to TRUE for debugging
 define('DEBUG_MODE', TRUE);

--- a/bl-plugins/about/metadata.json
+++ b/bl-plugins/about/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.20.0",
-	"releaseDate": "2026-04-09",
+	"version": "3.21.0",
+	"releaseDate": "2026-04-25",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": ""
 }

--- a/bl-plugins/alternative/metadata.json
+++ b/bl-plugins/alternative/metadata.json
@@ -2,10 +2,10 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.20.0",
-	"releaseDate": "2026-04-09",
+	"version": "3.21.0",
+	"releaseDate": "2026-04-25",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": "",
 	"type": "theme"
 }

--- a/bl-plugins/api/metadata.json
+++ b/bl-plugins/api/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.20.0",
-	"releaseDate": "2026-04-09",
+	"version": "3.21.0",
+	"releaseDate": "2026-04-25",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": ""
 }

--- a/bl-plugins/canonical/metadata.json
+++ b/bl-plugins/canonical/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.20.0",
-	"releaseDate": "2026-04-09",
+	"version": "3.21.0",
+	"releaseDate": "2026-04-25",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": ""
 }

--- a/bl-plugins/categories/metadata.json
+++ b/bl-plugins/categories/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.20.0",
-	"releaseDate": "2026-04-09",
+	"version": "3.21.0",
+	"releaseDate": "2026-04-25",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": ""
 }

--- a/bl-plugins/custom-fields-parser/metadata.json
+++ b/bl-plugins/custom-fields-parser/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.20.0",
-	"releaseDate": "2026-04-09",
+	"version": "3.21.0",
+	"releaseDate": "2026-04-25",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": ""
 }

--- a/bl-plugins/disqus/metadata.json
+++ b/bl-plugins/disqus/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.20.0",
-	"releaseDate": "2026-04-09",
+	"version": "3.21.0",
+	"releaseDate": "2026-04-25",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": ""
 }

--- a/bl-plugins/easymde/metadata.json
+++ b/bl-plugins/easymde/metadata.json
@@ -5,6 +5,6 @@
 	"version": "2.18.0",
 	"releaseDate": "2022-09-20",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": ""
 }

--- a/bl-plugins/hit-counter/metadata.json
+++ b/bl-plugins/hit-counter/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.20.0",
-	"releaseDate": "2026-04-09",
+	"version": "3.21.0",
+	"releaseDate": "2026-04-25",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": ""
 }

--- a/bl-plugins/html-code/metadata.json
+++ b/bl-plugins/html-code/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.20.0",
-	"releaseDate": "2026-04-09",
+	"version": "3.21.0",
+	"releaseDate": "2026-04-25",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": ""
 }

--- a/bl-plugins/links/metadata.json
+++ b/bl-plugins/links/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.20.0",
-	"releaseDate": "2026-04-09",
+	"version": "3.21.0",
+	"releaseDate": "2026-04-25",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": ""
 }

--- a/bl-plugins/maintenance-mode/metadata.json
+++ b/bl-plugins/maintenance-mode/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.20.0",
-	"releaseDate": "2026-04-09",
+	"version": "3.21.0",
+	"releaseDate": "2026-04-25",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": ""
 }

--- a/bl-plugins/navigation/metadata.json
+++ b/bl-plugins/navigation/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.20.0",
-	"releaseDate": "2026-04-09",
+	"version": "3.21.0",
+	"releaseDate": "2026-04-25",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": ""
 }

--- a/bl-plugins/opengraph/metadata.json
+++ b/bl-plugins/opengraph/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.20.0",
-	"releaseDate": "2026-04-09",
+	"version": "3.21.0",
+	"releaseDate": "2026-04-25",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": ""
 }

--- a/bl-plugins/popeye/metadata.json
+++ b/bl-plugins/popeye/metadata.json
@@ -2,10 +2,10 @@
   "author": "Bludit",
   "email": "",
   "website": "https://plugins.bludit.com",
-  "version": "3.20.0",
-  "releaseDate": "2026-04-09",
+  "version": "3.21.0",
+  "releaseDate": "2026-04-25",
   "license": "MIT",
-  "compatible": "3.20",
+  "compatible": "3.21",
   "notes": "",
   "type": "theme"
 }

--- a/bl-plugins/remote-content/metadata.json
+++ b/bl-plugins/remote-content/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com/plugin/remote-content",
-	"version": "3.20.0",
-	"releaseDate": "2026-04-09",
+	"version": "3.21.0",
+	"releaseDate": "2026-04-25",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": ""
 }

--- a/bl-plugins/robots/metadata.json
+++ b/bl-plugins/robots/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.20.0",
-	"releaseDate": "2026-04-09",
+	"version": "3.21.0",
+	"releaseDate": "2026-04-25",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": ""
 }

--- a/bl-plugins/rss/metadata.json
+++ b/bl-plugins/rss/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.20.0",
-	"releaseDate": "2026-04-09",
+	"version": "3.21.0",
+	"releaseDate": "2026-04-25",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": ""
 }

--- a/bl-plugins/search/metadata.json
+++ b/bl-plugins/search/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.20.0",
-	"releaseDate": "2026-04-09",
+	"version": "3.21.0",
+	"releaseDate": "2026-04-25",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": ""
 }

--- a/bl-plugins/sitemap/metadata.json
+++ b/bl-plugins/sitemap/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.20.0",
-	"releaseDate": "2026-04-09",
+	"version": "3.21.0",
+	"releaseDate": "2026-04-25",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": ""
 }

--- a/bl-plugins/static-pages/metadata.json
+++ b/bl-plugins/static-pages/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.20.0",
-	"releaseDate": "2026-04-09",
+	"version": "3.21.0",
+	"releaseDate": "2026-04-25",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": ""
 }

--- a/bl-plugins/tags/metadata.json
+++ b/bl-plugins/tags/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.20.0",
-	"releaseDate": "2026-04-09",
+	"version": "3.21.0",
+	"releaseDate": "2026-04-25",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": ""
 }

--- a/bl-plugins/tinymce/css/tinymce_toolbar.css
+++ b/bl-plugins/tinymce/css/tinymce_toolbar.css
@@ -2,10 +2,14 @@
 	border-top: none !important;
 }
 
-/* TinyMCE focus styling to match the theme: keep blue border but remove box-shadow */
-.tox-tinymce:focus, 
+/* TinyMCE focus styling to match the theme */
+.tox-tinymce:focus,
 .tox-tinymce--focused {
-	border: 1px solid #016DE7 !important;
+	border: 2px solid #b0bec5 !important;
 	box-shadow: none !important;
 	outline: none !important;
+}
+
+.tox-edit-focus .tox-edit-area::before {
+	opacity: 0 !important;
 }

--- a/bl-plugins/tinymce/metadata.json
+++ b/bl-plugins/tinymce/metadata.json
@@ -5,6 +5,6 @@
 	"version": "8.3.2",
 	"releaseDate": "2026-01-14",
 	"license": "GPL 2.0+",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": ""
 }

--- a/bl-plugins/twitter-cards/metadata.json
+++ b/bl-plugins/twitter-cards/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.20.0",
-	"releaseDate": "2026-04-09",
+	"version": "3.21.0",
+	"releaseDate": "2026-04-25",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": ""
 }

--- a/bl-plugins/version/metadata.json
+++ b/bl-plugins/version/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.20.0",
-	"releaseDate": "2026-04-09",
+	"version": "3.21.0",
+	"releaseDate": "2026-04-25",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": ""
 }

--- a/bl-plugins/visits-stats/metadata.json
+++ b/bl-plugins/visits-stats/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.20.0",
-	"releaseDate": "2026-04-09",
+	"version": "3.21.0",
+	"releaseDate": "2026-04-25",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": ""
 }

--- a/bl-themes/alternative/metadata.json
+++ b/bl-themes/alternative/metadata.json
@@ -2,10 +2,10 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://themes.bludit.com",
-	"version": "3.20.0",
-	"releaseDate": "2026-04-09",
+	"version": "3.21.0",
+	"releaseDate": "2026-04-25",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": "Improved accessibility, SEO with Schema.org, responsive design, and performance",
 	"plugin": "alternative"
 }

--- a/bl-themes/blogx/metadata.json
+++ b/bl-themes/blogx/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://themes.bludit.com",
-	"version": "3.20.0",
-	"releaseDate": "2026-04-09",
+	"version": "3.21.0",
+	"releaseDate": "2026-04-25",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": ""
 }

--- a/bl-themes/flavor/metadata.json
+++ b/bl-themes/flavor/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://themes.bludit.com",
-	"version": "3.20.0",
-	"releaseDate": "2026-04-09",
+	"version": "3.21.0",
+	"releaseDate": "2026-04-25",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": ""
 }

--- a/bl-themes/popeye/metadata.json
+++ b/bl-themes/popeye/metadata.json
@@ -2,10 +2,10 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://themes.bludit.com",
-	"version": "3.20.0",
-	"releaseDate": "2026-04-09",
+	"version": "3.21.0",
+	"releaseDate": "2026-04-25",
 	"license": "MIT",
-	"compatible": "3.20",
+	"compatible": "3.21",
 	"notes": "",
 	"plugin": "popeye"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated focus styling across inputs, form controls and editor components to a lighter neutral border with explicit outline removal for more consistent visuals.

* **Chores**
  * Bumped core release to 3.21.0 (ImperialEagle) and set release date to April 25, 2026.
  * Updated plugins and themes metadata for compatibility with the new release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->