### PR TITLE
fix: guard preview token against non-string before hash_equals (#1692)

### DIFF
--- a/bl-kernel/functions.php
+++ b/bl-kernel/functions.php
@@ -51,7 +51,8 @@ function buildThePage()
   }
 
   if ($page->draft() || $page->scheduled() || $page->autosave()) {
-    if (!hash_equals(hash_hmac('sha256', $page->uuid(), DB_SITE), $url->parameter('preview'))) {
+    $preview = $url->parameter('preview');
+    if (!is_string($preview) || !hash_equals(hash_hmac('sha256', $page->uuid(), DB_SITE), $preview)) {
       $url->setNotFound();
       return false;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced preview request validation for improved error handling. The system now verifies that all required parameters are present and valid before processing preview functionality. Requests with invalid or missing parameters will now return appropriate error responses, preventing unvalidated requests from being processed and improving overall system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->