### PR TITLE
fix: invalidate sessions for disabled users (GHSA-q42h-wpg8-5wwf)

### DIFF
--- a/bl-kernel/login.class.php
+++ b/bl-kernel/login.class.php
@@ -43,6 +43,12 @@ class Login
 		if (Session::get('fingerPrint') === $this->fingerPrint()) {
 			$username = Session::get('username');
 			if (!empty($username)) {
+				$userDB = $this->users->getUserDB($username);
+				if ($userDB === false || $userDB['password'] === '!') {
+					Log::set(__METHOD__ . LOG_SEP . 'User no longer exists or is disabled, destroying the session.');
+					Session::destroy();
+					return false;
+				}
 				return true;
 			} else {
 				Log::set(__METHOD__ . LOG_SEP . 'Session username empty, destroying the session.');

--- a/bl-kernel/users.class.php
+++ b/bl-kernel/users.class.php
@@ -57,6 +57,8 @@ class Users extends dbJSON {
 	public function disableUser($username)
 	{
 		$this->db[$username]['password'] = '!';
+		$this->db[$username]['tokenRemember'] = '';
+		$this->db[$username]['tokenAuth'] = $this->generateAuthToken();
 		return $this->save();
 	}
 


### PR DESCRIPTION
  Fixes https://github.com/bludit/bludit/security/advisories/GHSA-q42h-wpg8-5wwf

  - `disableUser()` now clears tokenRemember and rotates tokenAuth on disable
  - `isLogged()` now validates user still exists and is not disabled on every auth check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Login sessions now validate user accounts and deny access if the account is disabled or no longer exists.
  * User account disabling now properly invalidates all stored authentication tokens to prevent unauthorized access with previously saved credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->