### PR TITLE
chore: bump version to 3.22.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 dbgenerator.php
+tests/
 bl-content/*
 !bl-content/.keep
 bl-content-migrator

--- a/bl-kernel/boot/init.php
+++ b/bl-kernel/boot/init.php
@@ -1,10 +1,10 @@
 <?php defined('BLUDIT') or die('Bludit CMS.');
 
 // Bludit version
-define('BLUDIT_VERSION',        '3.21.1');
-define('BLUDIT_CODENAME',       'ImperialEagle');
-define('BLUDIT_RELEASE_DATE',   '2026-05-01');
-define('BLUDIT_BUILD',          '20260501');
+define('BLUDIT_VERSION',        '3.22.0');
+define('BLUDIT_CODENAME',       'BrownBear');
+define('BLUDIT_RELEASE_DATE',   '2026-05-10');
+define('BLUDIT_BUILD',          '20260510');
 
 // Change to TRUE for debugging
 define('DEBUG_MODE', FALSE);

--- a/bl-plugins/about/metadata.json
+++ b/bl-plugins/about/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.21.1",
-	"releaseDate": "2026-05-01",
+	"version": "3.22.0",
+	"releaseDate": "2026-05-10",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": ""
 }

--- a/bl-plugins/alternative/metadata.json
+++ b/bl-plugins/alternative/metadata.json
@@ -2,10 +2,10 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.21.1",
-	"releaseDate": "2026-05-01",
+	"version": "3.22.0",
+	"releaseDate": "2026-05-10",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": "",
 	"type": "theme"
 }

--- a/bl-plugins/api/metadata.json
+++ b/bl-plugins/api/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.21.1",
-	"releaseDate": "2026-05-01",
+	"version": "3.22.0",
+	"releaseDate": "2026-05-10",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": ""
 }

--- a/bl-plugins/canonical/metadata.json
+++ b/bl-plugins/canonical/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.21.1",
-	"releaseDate": "2026-05-01",
+	"version": "3.22.0",
+	"releaseDate": "2026-05-10",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": ""
 }

--- a/bl-plugins/categories/metadata.json
+++ b/bl-plugins/categories/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.21.1",
-	"releaseDate": "2026-05-01",
+	"version": "3.22.0",
+	"releaseDate": "2026-05-10",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": ""
 }

--- a/bl-plugins/custom-fields-parser/metadata.json
+++ b/bl-plugins/custom-fields-parser/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.21.1",
-	"releaseDate": "2026-05-01",
+	"version": "3.22.0",
+	"releaseDate": "2026-05-10",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": ""
 }

--- a/bl-plugins/disqus/metadata.json
+++ b/bl-plugins/disqus/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.21.1",
-	"releaseDate": "2026-05-01",
+	"version": "3.22.0",
+	"releaseDate": "2026-05-10",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": ""
 }

--- a/bl-plugins/easymde/metadata.json
+++ b/bl-plugins/easymde/metadata.json
@@ -5,6 +5,6 @@
 	"version": "2.18.0",
 	"releaseDate": "2022-09-20",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": ""
 }

--- a/bl-plugins/hit-counter/metadata.json
+++ b/bl-plugins/hit-counter/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.21.1",
-	"releaseDate": "2026-05-01",
+	"version": "3.22.0",
+	"releaseDate": "2026-05-10",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": ""
 }

--- a/bl-plugins/html-code/metadata.json
+++ b/bl-plugins/html-code/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.21.1",
-	"releaseDate": "2026-05-01",
+	"version": "3.22.0",
+	"releaseDate": "2026-05-10",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": ""
 }

--- a/bl-plugins/links/metadata.json
+++ b/bl-plugins/links/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.21.1",
-	"releaseDate": "2026-05-01",
+	"version": "3.22.0",
+	"releaseDate": "2026-05-10",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": ""
 }

--- a/bl-plugins/maintenance-mode/metadata.json
+++ b/bl-plugins/maintenance-mode/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.21.1",
-	"releaseDate": "2026-05-01",
+	"version": "3.22.0",
+	"releaseDate": "2026-05-10",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": ""
 }

--- a/bl-plugins/navigation/metadata.json
+++ b/bl-plugins/navigation/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.21.1",
-	"releaseDate": "2026-05-01",
+	"version": "3.22.0",
+	"releaseDate": "2026-05-10",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": ""
 }

--- a/bl-plugins/opengraph/metadata.json
+++ b/bl-plugins/opengraph/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.21.1",
-	"releaseDate": "2026-05-01",
+	"version": "3.22.0",
+	"releaseDate": "2026-05-10",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": ""
 }

--- a/bl-plugins/popeye/metadata.json
+++ b/bl-plugins/popeye/metadata.json
@@ -2,10 +2,10 @@
   "author": "Bludit",
   "email": "",
   "website": "https://plugins.bludit.com",
-  "version": "3.21.1",
-  "releaseDate": "2026-05-01",
+  "version": "3.22.0",
+  "releaseDate": "2026-05-10",
   "license": "MIT",
-  "compatible": "3.21",
+  "compatible": "3.22",
   "notes": "",
   "type": "theme"
 }

--- a/bl-plugins/remote-content/metadata.json
+++ b/bl-plugins/remote-content/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com/plugin/remote-content",
-	"version": "3.21.1",
-	"releaseDate": "2026-05-01",
+	"version": "3.22.0",
+	"releaseDate": "2026-05-10",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": ""
 }

--- a/bl-plugins/robots/metadata.json
+++ b/bl-plugins/robots/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.21.1",
-	"releaseDate": "2026-05-01",
+	"version": "3.22.0",
+	"releaseDate": "2026-05-10",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": ""
 }

--- a/bl-plugins/rss/metadata.json
+++ b/bl-plugins/rss/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.21.1",
-	"releaseDate": "2026-05-01",
+	"version": "3.22.0",
+	"releaseDate": "2026-05-10",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": ""
 }

--- a/bl-plugins/search/metadata.json
+++ b/bl-plugins/search/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.21.1",
-	"releaseDate": "2026-05-01",
+	"version": "3.22.0",
+	"releaseDate": "2026-05-10",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": ""
 }

--- a/bl-plugins/sitemap/metadata.json
+++ b/bl-plugins/sitemap/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.21.1",
-	"releaseDate": "2026-05-01",
+	"version": "3.22.0",
+	"releaseDate": "2026-05-10",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": ""
 }

--- a/bl-plugins/static-pages/metadata.json
+++ b/bl-plugins/static-pages/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.21.1",
-	"releaseDate": "2026-05-01",
+	"version": "3.22.0",
+	"releaseDate": "2026-05-10",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": ""
 }

--- a/bl-plugins/tags/metadata.json
+++ b/bl-plugins/tags/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.21.1",
-	"releaseDate": "2026-05-01",
+	"version": "3.22.0",
+	"releaseDate": "2026-05-10",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": ""
 }

--- a/bl-plugins/tinymce/metadata.json
+++ b/bl-plugins/tinymce/metadata.json
@@ -5,6 +5,6 @@
 	"version": "8.3.2",
 	"releaseDate": "2026-01-14",
 	"license": "GPL 2.0+",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": ""
 }

--- a/bl-plugins/twitter-cards/metadata.json
+++ b/bl-plugins/twitter-cards/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.21.1",
-	"releaseDate": "2026-05-01",
+	"version": "3.22.0",
+	"releaseDate": "2026-05-10",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": ""
 }

--- a/bl-plugins/version/metadata.json
+++ b/bl-plugins/version/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.21.1",
-	"releaseDate": "2026-05-01",
+	"version": "3.22.0",
+	"releaseDate": "2026-05-10",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": ""
 }

--- a/bl-plugins/visits-stats/metadata.json
+++ b/bl-plugins/visits-stats/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.21.1",
-	"releaseDate": "2026-05-01",
+	"version": "3.22.0",
+	"releaseDate": "2026-05-10",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": ""
 }

--- a/bl-themes/alternative/metadata.json
+++ b/bl-themes/alternative/metadata.json
@@ -2,10 +2,10 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://themes.bludit.com",
-	"version": "3.21.1",
-	"releaseDate": "2026-05-01",
+	"version": "3.22.0",
+	"releaseDate": "2026-05-10",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": "Improved accessibility, SEO with Schema.org, responsive design, and performance",
 	"plugin": "alternative"
 }

--- a/bl-themes/blogx/metadata.json
+++ b/bl-themes/blogx/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://themes.bludit.com",
-	"version": "3.21.1",
-	"releaseDate": "2026-05-01",
+	"version": "3.22.0",
+	"releaseDate": "2026-05-10",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": ""
 }

--- a/bl-themes/flavor/metadata.json
+++ b/bl-themes/flavor/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://themes.bludit.com",
-	"version": "3.21.1",
-	"releaseDate": "2026-05-01",
+	"version": "3.22.0",
+	"releaseDate": "2026-05-10",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": ""
 }

--- a/bl-themes/popeye/metadata.json
+++ b/bl-themes/popeye/metadata.json
@@ -2,10 +2,10 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://themes.bludit.com",
-	"version": "3.21.1",
-	"releaseDate": "2026-05-01",
+	"version": "3.22.0",
+	"releaseDate": "2026-05-10",
 	"license": "MIT",
-	"compatible": "3.21",
+	"compatible": "3.22",
 	"notes": "",
 	"plugin": "popeye"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Released Bludit core to version 3.22.0, codenamed BrownBear, with updated release date of May 10, 2026.
  * Updated all 26 bundled plugins to version 3.22.0 with compatibility adjustments to support the new core version.
  * Updated all 4 bundled themes to version 3.22.0 with compatibility adjustments to support the new core version.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bludit/bludit/pull/1708)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->