### PR TITLE
fix: add untagged and total params to getList and countByType, and fi…

### DIFF
--- a/bl-kernel/pages.class.php
+++ b/bl-kernel/pages.class.php
@@ -546,22 +546,28 @@ class Pages extends dbJSON
 	// (int) $pageNumber, the page number
 	// (int) $numberOfItems, amount of items to return, if -1 returns all the items
 	// (boolean) $onlyPublished, TRUE to return only published pages
-	public function getList($pageNumber, $numberOfItems, $published = true, $static = false, $sticky = false, $draft = false, $scheduled = false)
+	public function getList($pageNumber, $numberOfItems, $published = true, $static = false, $sticky = false, $draft = false, $scheduled = false, $untagged = false, &$total = null)
 	{
 		$list = array();
 		foreach ($this->db as $key => $fields) {
+			$typeMatch = false;
 			if ($published && $fields['type'] == 'published') {
-				array_push($list, $key);
+				$typeMatch = true;
 			} elseif ($static && $fields['type'] == 'static') {
-				array_push($list, $key);
+				$typeMatch = true;
 			} elseif ($sticky && $fields['type'] == 'sticky') {
-				array_push($list, $key);
+				$typeMatch = true;
 			} elseif ($draft && $fields['type'] == 'draft') {
-				array_push($list, $key);
+				$typeMatch = true;
 			} elseif ($scheduled && $fields['type'] == 'scheduled') {
+				$typeMatch = true;
+			}
+			if ($typeMatch && (!$untagged || empty($fields['tags']))) {
 				array_push($list, $key);
 			}
 		}
+
+		$total = count($list);
 
 		if ($numberOfItems == -1) {
 			return $list;
@@ -570,7 +576,6 @@ class Pages extends dbJSON
 		// The first page number is 1, so the real is 0
 		$realPageNumber = $pageNumber - 1;
 
-		$total = count($list);
 		$init = (int) $numberOfItems * $realPageNumber;
 		$end  = (int) min(($init + $numberOfItems - 1), $total);
 		$outrange = $init < 0 ? true : $init > $end;
@@ -594,21 +599,25 @@ class Pages extends dbJSON
 		return count($this->db);
 	}
 
-	// Returns the count of pages matching the given type filters.
-	// Same filter semantics as getList(), useful for paginated listings that need a total.
-	public function countByType($published = true, $static = false, $sticky = false, $draft = false, $scheduled = false)
+	// Returns the count of pages matching the given type and optional untagged filters.
+	// Same filter semantics as getList().
+	public function countByType($published = true, $static = false, $sticky = false, $draft = false, $scheduled = false, $untagged = false)
 	{
 		$count = 0;
 		foreach ($this->db as $key => $fields) {
+			$typeMatch = false;
 			if ($published && $fields['type'] == 'published') {
-				$count++;
+				$typeMatch = true;
 			} elseif ($static && $fields['type'] == 'static') {
-				$count++;
+				$typeMatch = true;
 			} elseif ($sticky && $fields['type'] == 'sticky') {
-				$count++;
+				$typeMatch = true;
 			} elseif ($draft && $fields['type'] == 'draft') {
-				$count++;
+				$typeMatch = true;
 			} elseif ($scheduled && $fields['type'] == 'scheduled') {
+				$typeMatch = true;
+			}
+			if ($typeMatch && (!$untagged || empty($fields['tags']))) {
 				$count++;
 			}
 		}

--- a/bl-plugins/api/plugin.php
+++ b/bl-plugins/api/plugin.php
@@ -418,16 +418,13 @@ class pluginAPI extends Plugin
 			$numberOfItems = 15;
 		}
 
-		$list = $pages->getList($pageNumber, $numberOfItems, $published, $static, $sticky, $draft, $scheduled);
+		$total = 0;
+		$list = $pages->getList($pageNumber, $numberOfItems, $published, $static, $sticky, $draft, $scheduled, $untagged, $total);
 		// getList() returns false when pageNumber is past the end; treat as empty.
 		if ($list === false) {
 			$list = array();
 		}
 
-		// total reflects the count of pages matching the type filters; the
-		// untagged filter is applied to the page slice below, so it is not
-		// reflected in this total.
-		$total = $pages->countByType($published, $static, $sticky, $draft, $scheduled);
 		$hasMore = ($numberOfItems > 0) && (($pageNumber * $numberOfItems) < $total);
 
 		$tmp = array(
@@ -445,16 +442,8 @@ class pluginAPI extends Plugin
 
 		foreach ($list as $pageKey) {
 			try {
-				// Create the page object from the page key
 				$page = new Page($pageKey);
-				if ($untagged) {
-					if (empty($page->tags())) {
-						// Push the page to the data array for the response
-						array_push($tmp['data'], $page->json($returnsArray = true));
-					}
-				} else {
-					array_push($tmp['data'], $page->json($returnsArray = true));
-				}
+				array_push($tmp['data'], $page->json($returnsArray = true));
 			} catch (Exception $e) {
 				// Continue
 			}


### PR DESCRIPTION
…x: compute meta total from untagged-aware single pass in getPages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now filter API requests to display only untagged content for more targeted data retrieval
  * Improved pagination with accurate total count tracking for filtered result sets, providing better visibility into complete data availability
  * Filtering now works consistently across all content types and status options

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bludit/bludit/pull/1710)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->