### PR TITLE
fix: path traversal to arbitrary file deletion in delete-image (GHSA-3643-grc6-frmp)

### DIFF
--- a/bl-kernel/ajax/delete-image.php
+++ b/bl-kernel/ajax/delete-image.php
@@ -21,7 +21,7 @@ if ($filename===false) {
 }
 
 if ($uuid && IMAGE_RESTRICT) {
-	if (Text::stringContains($uuid, DS, false)) {
+	if (Text::stringContains($uuid, '/', false) || Text::stringContains($uuid, '\\', false)) {
 		ajaxResponse(1, 'Invalid uuid.');
 	}
 	$imagePath = PATH_UPLOADS_PAGES.$uuid.DS;

--- a/bl-kernel/ajax/delete-image.php
+++ b/bl-kernel/ajax/delete-image.php
@@ -32,7 +32,7 @@ if ($uuid && IMAGE_RESTRICT) {
 }
 
 // Delete the original
-if (Sanitize::pathFile($imagePath.$filename)) {
+if (Sanitize::pathFile($imagePath, $filename)) {
 	Filesystem::rmfile($imagePath.$filename);
 }
 
@@ -42,7 +42,7 @@ if (Sanitize::pathFile($imagePath.$filename)) {
 // forced to .jpg while the original kept its real extension. Before deleting
 // a mismatched candidate, verify no other original owns that extension, to
 // avoid taking out an unrelated image's thumbnail.
-if (Sanitize::pathFile($thumbnailPath.$filename) && is_file($thumbnailPath.$filename)) {
+if (Sanitize::pathFile($thumbnailPath, $filename) && is_file($thumbnailPath.$filename)) {
 	Filesystem::rmfile($thumbnailPath.$filename);
 } else {
 	$base = pathinfo($filename, PATHINFO_FILENAME);
@@ -54,7 +54,7 @@ if (Sanitize::pathFile($thumbnailPath.$filename) && is_file($thumbnailPath.$file
 		if (is_file($imagePath.$candidate)) {
 			continue;
 		}
-		if (Sanitize::pathFile($thumbnailPath.$candidate) && is_file($thumbnailPath.$candidate)) {
+		if (Sanitize::pathFile($thumbnailPath, $candidate) && is_file($thumbnailPath.$candidate)) {
 			Filesystem::rmfile($thumbnailPath.$candidate);
 		}
 	}

--- a/bl-kernel/helpers/sanitize.class.php
+++ b/bl-kernel/helpers/sanitize.class.php
@@ -30,9 +30,14 @@ class Sanitize {
 		return htmlspecialchars_decode($text, $flags);
 	}
 
+	// Validate a file path. With two arguments performs a path-traversal check:
+	// the resolved $path.$file must live inside the resolved $path. With a single
+	// argument no base is supplied, so only the existence of the file is checked
+	// (callers needing traversal protection must pass the base directory as $path
+	// and the untrusted segment as $file).
 	public static function pathFile($path, $file=false)
 	{
-		if ($file!==false){
+		if ($file!==false) {
 			$fullPath = $path.$file;
 		} else {
 			$fullPath = $path;
@@ -50,6 +55,12 @@ class Sanitize {
 		// If $real is FALSE the file does not exist.
 		if ($real===false) {
 			return false;
+		}
+
+		// Without a base directory we cannot validate traversal; existence is all
+		// we can answer.
+		if ($file===false) {
+			return true;
 		}
 
 		// Resolve the base directory to validate against path traversal.

--- a/bl-kernel/helpers/sanitize.class.php
+++ b/bl-kernel/helpers/sanitize.class.php
@@ -49,7 +49,7 @@ class Sanitize {
 		if (CHECK_SYMBOLIC_LINKS) {
 			$real = realpath($fullPath);
 		} else {
-			$real = file_exists($fullPath)?$fullPath:false;
+			$real = file_exists($fullPath) ? self::normalizePath($fullPath) : false;
 		}
 
 		// If $real is FALSE the file does not exist.
@@ -75,6 +75,24 @@ class Sanitize {
 		}
 
 		return true;
+	}
+
+	// Resolves dot-segments in a path without following symlinks.
+	private static function normalizePath($path)
+	{
+		$path = str_replace('/', DS, $path);
+		$isAbsolute = (strlen($path) > 0 && $path[0] === DS);
+		$parts = explode(DS, $path);
+		$normalized = [];
+		foreach ($parts as $part) {
+			if ($part === '..') {
+				array_pop($normalized);
+			} elseif ($part !== '' && $part !== '.') {
+				$normalized[] = $part;
+			}
+		}
+		$result = implode(DS, $normalized);
+		return $isAbsolute ? DS . $result : $result;
 	}
 
 	// Returns the email without illegal characters.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for image and thumbnail deletion to prevent unsafe path characters and improve handling of directory/filename combinations.
  * Enhanced internal path-resolution checks to reduce path-traversal risk and ensure thumbnails are reliably removed when present.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bludit/bludit/pull/1711?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->