### PR TITLE
 fix: require fileinfo extension and replace openssl_random_pseudo_bytes with random_bytes

### DIFF
--- a/bl-kernel/security.class.php
+++ b/bl-kernel/security.class.php
@@ -20,7 +20,7 @@ class Security extends dbJSON
 	// Generate and save the token in Session
 	public function generateTokenCSRF()
 	{
-		$token = bin2hex( openssl_random_pseudo_bytes(64) );
+		$token = bin2hex( random_bytes(64) );
 		Session::set('tokenCSRF', $token);
 		Log::set(__METHOD__.LOG_SEP.'New Token CSRF ['.$token.']');
 	}

--- a/bl-kernel/users.class.php
+++ b/bl-kernel/users.class.php
@@ -143,7 +143,7 @@ class Users extends dbJSON {
 
 	public function generateAuthToken()
 	{
-		return bin2hex( openssl_random_pseudo_bytes(64) );
+		return bin2hex( random_bytes(64) );
 	}
 
 	public function generateRememberToken()

--- a/install.php
+++ b/install.php
@@ -15,7 +15,7 @@ if (version_compare(phpversion(), '8.0', '<')) {
 }
 
 // Check PHP modules
-$modulesRequired = array('mbstring', 'json', 'gd', 'dom', 'session');
+$modulesRequired = array('mbstring', 'json', 'gd', 'dom', 'session', 'fileinfo');
 $modulesRequiredExit = false;
 $modulesRequiredMissing = '';
 foreach ($modulesRequired as $module) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced token generation security mechanisms
  * Added `fileinfo` as a required PHP extension; installation will fail if this module is unavailable on your server

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bludit/bludit/pull/1713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->