### PR TITLE
feat: add admin hooks for categories/content

### DIFF
--- a/bl-kernel/admin/controllers/edit-category.php
+++ b/bl-kernel/admin/controllers/edit-category.php
@@ -20,9 +20,13 @@ checkRole(array('admin'));
 
 if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 	if ($_POST['action']=='delete') {
-		deleteCategory($_POST);
+        if (deleteCategory($_POST)) {
+            Theme::plugins('adminControllerDeleteCategory', array('key' => $_POST['oldKey']));
+        }
 	} elseif ($_POST['action']=='edit') {
-		editCategory($_POST);
+        if (editCategory($_POST)) {
+            Theme::plugins('adminControllerEditCategory', array('key' => $_POST['oldKey'], 'newKey' => $_POST['newKey']));
+        }
 	}
 
 	Redirect::page('categories');

--- a/bl-kernel/admin/themes/booty/html/sidebar.php
+++ b/bl-kernel/admin/themes/booty/html/sidebar.php
@@ -44,6 +44,19 @@
 		<a class="nav-link" href="<?php echo HTML_PATH_ADMIN_ROOT.'users' ?>"><span class="fa fa-users"></span><?php $L->p('Users') ?></a>
 	</li>
 
+	<?php
+		if (!empty($plugins['adminContentSidebar'])) {
+			foreach ($plugins['adminContentSidebar'] as $pluginSidebar) {
+            $sidebarHtml = $pluginSidebar->adminContentSidebar();
+            if (is_string($sidebarHtml) && $sidebarHtml !== '') {
+                echo '<li class="nav-item">';
+                echo $sidebarHtml;
+                echo '</li>';
+            }
+			}
+		}
+	?>
+
 	<li class="nav-item mt-3">
 		<h4><?php $L->p('Settings') ?></h4>
 	</li>
@@ -68,9 +81,12 @@
 			if (!empty($plugins['adminSidebar'])) {
 				echo '<li class="nav-item"><hr></li>';
 				foreach ($plugins['adminSidebar'] as $pluginSidebar) {
-					echo '<li class="nav-item">';
-					echo $pluginSidebar->adminSidebar();
-					echo '</li>';
+		            $sidebarHtml = $pluginSidebar->adminSidebar();
+					if (is_string($sidebarHtml) && $sidebarHtml !== '') {
+						echo '<li class="nav-item">';
+						echo $sidebarHtml;
+						echo '</li>';
+					}
 				}
 			}
 		?>

--- a/bl-kernel/admin/views/content.php
+++ b/bl-kernel/admin/views/content.php
@@ -27,6 +27,19 @@ function moveTypeLabel($current, $target, $L) {
 	return isset($labels[$target]) ? $labels[$target] : $target;
 }
 
+function renderAdminContentListActions($pageKey) {
+    global $plugins;
+    if (!empty($plugins['adminContentListActions'])) {
+        foreach ($plugins['adminContentListActions'] as $plugin) {
+            $actionHtml = $plugin->adminContentListActions($pageKey);
+            if (is_string($actionHtml) && $actionHtml !== '') {
+                echo $actionHtml;
+            }
+        }
+    }
+}
+
+
 // Render a single row (or row + nested children) for a page key.
 // $type controls which columns/buttons are shown; $isSticky adds the Sticky badge
 // and flips the toggle button into "Unstick" mode.
@@ -120,6 +133,9 @@ function tableRow($pageKey, $type, $isSticky = false, $renderChildren = false) {
 		echo '<div class="dropdown-divider"></div>';
 		echo '<a href="#" class="dropdown-item text-danger deletePageButton" data-toggle="modal" data-target="#jsdeletePageModal" data-key="'.$page->key().'"><i class="fa fa-trash fa-fw mr-2"></i>'.$L->g('Delete').'</a>';
 	}
+
+    renderAdminContentListActions($pageKey);
+
 	echo '</div></div>';
 	echo '</td>';
 	echo '</tr>';
@@ -151,6 +167,9 @@ function tableRow($pageKey, $type, $isSticky = false, $renderChildren = false) {
 			echo '<a class="dropdown-item" href="'.HTML_PATH_ADMIN_ROOT.'edit-content/'.$child->key().'"><i class="fa fa-edit fa-fw mr-2"></i>'.$L->g('Edit').'</a>';
 			echo '<div class="dropdown-divider"></div>';
 			echo '<a href="#" class="dropdown-item text-danger deletePageButton" data-toggle="modal" data-target="#jsdeletePageModal" data-key="'.$child->key().'"><i class="fa fa-trash fa-fw mr-2"></i>'.$L->g('Delete').'</a>';
+
+			renderAdminContentListActions($child->key());
+
 			echo '</div></div>';
 			echo '</td>';
 			echo '</tr>';

--- a/bl-kernel/admin/views/edit-category.php
+++ b/bl-kernel/admin/views/edit-category.php
@@ -65,8 +65,9 @@
 		'tip'=>DOMAIN_CATEGORIES.$categoryMap['key']
 	));
 
-echo Bootstrap::formClose();
-
+	Theme::plugins('adminViewEditCategoryForm');
+	echo Bootstrap::formClose();
+	Theme::plugins('adminViewEditCategory');
 ?>
 
 <!-- Modal for delete category -->

--- a/bl-kernel/boot/rules/60.plugins.php
+++ b/bl-kernel/boot/rules/60.plugins.php
@@ -22,6 +22,7 @@ $plugins = array(
 	'adminBodyEnd'=>array(),
 	'adminSidebar'=>array(),
 	'adminContentSidebar'=>array(),
+	'adminContentListActions'=>array(),
 	'dashboard'=>array(),
 	'editorToolbar'=>array(),
 
@@ -33,6 +34,11 @@ $plugins = array(
 	'afterPageCreate'=>array(),
 	'afterPageModify'=>array(),
 	'afterPageDelete'=>array(),
+
+	'adminControllerDeleteCategory'=>array(),
+	'adminControllerEditCategory'=>array(),
+	'adminViewEditCategoryForm'=>array(),
+	'adminViewEditCategory'=>array(),
 
 	'loginHead'=>array(),
 	'loginBodyBegin'=>array(),

--- a/bl-kernel/helpers/sanitize.class.php
+++ b/bl-kernel/helpers/sanitize.class.php
@@ -15,6 +15,14 @@ class Sanitize {
 			$flags = ENT_COMPAT|ENT_HTML5;
 		}
 
+		// Massage for strict typing (PHP8 breakage)
+		if (is_array($text)) {
+           $encoded = json_encode($text, JSON_INVALID_UTF8_SUBSTITUTE);
+           $text = ($encoded === false) ? '' : $encoded;
+		} else {
+			$text = (string)$text;
+		}
+                
 		return htmlspecialchars($text, $flags, CHARSET);
 	}
 


### PR DESCRIPTION
...and fix PHP 8 strict typing in Sanitize.

One of the hooks work had started on, so I basically just completed that (injecting content into `Content` area of admin bar. In addition to that I wanted to hook into category editing and context menu of pages.

I will likely release a few plugins that depend on these hooks should they make it upstream.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugins can add items to the admin sidebar and to per-item action menus.
  * Plugin-supplied actions can appear in parent and child content rows and in category edit views.

* **Bug Fixes**
  * Plugin notifications for category edits/deletes now fire only after the action succeeds.
  * HTML sanitization strengthened to safely handle non-string or structured inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bludit/bludit/pull/1715?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->