### PR TITLE
Configurable sandbox_iframes_exclusions option for TinyMCE plugin

### DIFF
--- a/bl-plugins/tinymce/languages/en.json
+++ b/bl-plugins/tinymce/languages/en.json
@@ -9,5 +9,6 @@
 	"context-menu": "Context menu",
 	"context-menu-tip": "Empty field to disable the editor’s context menu.",
 	"codesample-languages": "Codesample languages",
-	"codesample-supported-laguages": "Programming languages supported by Prism."
+	"codesample-supported-laguages": "Programming languages supported by Prism.",
+	"sandbox-iframes-exclusions": "Sandbox iframes exclusions"
 }

--- a/bl-plugins/tinymce/plugin.php
+++ b/bl-plugins/tinymce/plugin.php
@@ -15,6 +15,7 @@ class pluginTinymce extends Plugin
 			'toolbar2' => '',
 			'contextmenu' => 'link image table',
 			'plugins' => 'code autolink image link pagebreak advlist lists table fullscreen media searchreplace wordcount emoticons charmap codesample',
+			'sandboxiframesexclusions' => '',
 			'codesampleLanguages' => 'HTML/XML markup|JavaScript javascript|CSS css|PHP php|Ruby ruby|Python python|Java java|C c|C# sharp|C++ cpp'
 		);
 	}
@@ -46,6 +47,11 @@ class pluginTinymce extends Plugin
 		$html .= '<div>';
 		$html .= '<label>' . $L->get('Plugins') . '</label>';
 		$html .= '<input name="plugins" id="jsplugins" type="text" dir="auto" value="' . $this->getValue('plugins') . '">';
+		$html .= '</div>';
+
+		$html .= '<div>';
+		$html .= '<label>' . $L->get('sandbox-iframes-exclusions') . '</label>';
+		$html .= '<input name="sandboxiframesexclusions" id="jssandboxiframesexclusions" type="text" dir="auto" value="' . $this->getValue('sandboxiframesexclusions') . '">';
 		$html .= '</div>';
 
 		if (strpos($this->getValue('plugins'), 'codesample') !== false) {
@@ -89,6 +95,10 @@ class pluginTinymce extends Plugin
 		$plugins = $this->getValue('plugins');
 		// Convert space-separated plugins to JavaScript array format
 		$pluginsArray = implode("', '", array_filter(explode(' ', $plugins)));
+		$version = $this->version();
+		$sandboxiframesexclusions = $this->getValue('sandboxiframesexclusions');
+		// Convert space-separated sandbox iframe exclusions to JavaScript array format
+		$sandboxiframesexclusionsArray = implode("', '", array_filter(explode(' ', $sandboxiframesexclusions)));
 		$version = $this->version();
 
 		$codesampleConfig = '';
@@ -162,7 +172,8 @@ class pluginTinymce extends Plugin
 		content_css: "$content_css",
 		codesample_languages: [$codesampleConfig],
 		image_description: true,
-		image_advtab: true
+		image_advtab: true,
+		sandbox_iframes_exclusions: ['$sandboxiframesexclusionsArray']
 	});
 
 </script>

--- a/bl-plugins/tinymce/plugin.php
+++ b/bl-plugins/tinymce/plugin.php
@@ -98,7 +98,9 @@ class pluginTinymce extends Plugin
 		$version = $this->version();
 		$sandboxiframesexclusions = $this->getValue('sandboxiframesexclusions');
 		// Convert space-separated sandbox iframe exclusions to JavaScript array format
-		$sandboxiframesexclusionsArray = implode("', '", array_filter(explode(' ', $sandboxiframesexclusions)));
+		$sandboxiframesexclusionsArray = array_filter(explode(' ', $sandboxiframesexclusions));
+		$sandboxiframesexclusionsArray =
+			count($sandboxiframesexclusionsArray) ? "'" . implode("', '", $sandboxiframesexclusionsArray) . "'" : "";
 		$version = $this->version();
 
 		$codesampleConfig = '';
@@ -173,7 +175,7 @@ class pluginTinymce extends Plugin
 		codesample_languages: [$codesampleConfig],
 		image_description: true,
 		image_advtab: true,
-		sandbox_iframes_exclusions: ['$sandboxiframesexclusionsArray']
+		sandbox_iframes_exclusions: [$sandboxiframesexclusionsArray]
 	});
 
 </script>


### PR DESCRIPTION
I've recently updated bludit and found out all my iframes stopped working. It turned out TinyMCE enabled iframe sandboxing by default.  This change adds support for configuring [sandbox-iframes-exclusions](https://www.tiny.cloud/docs/tinymce/latest/content-filtering/#sandbox-iframes-exclusions) option in TinyMCE plugin settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to control which iframes are excluded from sandboxing in the TinyMCE editor (admin-configurable).

* **Bug Fixes**
  * Updated a translation key (previous typo) that may change the displayed text for the "Programming languages supported by Prism." entry and added a new translation entry for sandbox iframe exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->