### PR TITLE
fix: sanitize SVG uploads to strip active content (GHSA-g9j2-xqqj-5h56)

### DIFF
--- a/bl-kernel/functions.php
+++ b/bl-kernel/functions.php
@@ -990,7 +990,10 @@ function sanitizeSVG($file)
 		$toRemove = array();
 		foreach ($element->attributes as $attr) {
 			$name  = strtolower($attr->localName);
-			$value = strtolower(trim($attr->value));
+			// Strip control characters/whitespace before the scheme check —
+			// browsers ignore them, so "java&#x0A;script:" would otherwise
+			// slip past a plain strpos('javascript:').
+			$value = strtolower(preg_replace('/[\x00-\x20\x7f]+/', '', $attr->value));
 			if (strpos($name, 'on') === 0) {
 				$toRemove[] = $attr;
 			} elseif (in_array($name, array('href', 'action', 'formaction', 'src'), true)

--- a/bl-kernel/functions.php
+++ b/bl-kernel/functions.php
@@ -961,10 +961,19 @@ function sanitizeSVG($file)
 	}
 
 	$dom = new DOMDocument();
-	libxml_use_internal_errors(true);
+	$previousLibxmlErrors = libxml_use_internal_errors(true);
 	$loaded = $dom->loadXML($content);
 	libxml_clear_errors();
+	libxml_use_internal_errors($previousLibxmlErrors);
 	if (!$loaded) {
+		return false;
+	}
+
+	// Reject any document with a DOCTYPE. Entity definitions would otherwise
+	// survive into the output, and content entity references are not expanded
+	// into the DOM — so the XPath filters never see them and a downstream
+	// parser could reintroduce active content (XXE / entity expansion).
+	if ($dom->doctype !== null) {
 		return false;
 	}
 

--- a/bl-kernel/functions.php
+++ b/bl-kernel/functions.php
@@ -948,6 +948,76 @@ function ajaxResponse($status = 0, $message = "", $data = array())
 |
 | @return	string/boolean	Path and filename of the new image or FALSE if there were some error
 */
+
+// Strips active content from an SVG file in-place using DOMDocument.
+// Removes <script>, <foreignObject>, on* event attributes, javascript: URIs,
+// and <use> elements with external hrefs. Returns false if the file cannot be
+// parsed as valid XML, so callers should treat false as a rejection.
+function sanitizeSVG($file)
+{
+	$content = file_get_contents($file);
+	if ($content === false) {
+		return false;
+	}
+
+	$dom = new DOMDocument();
+	libxml_use_internal_errors(true);
+	$loaded = $dom->loadXML($content);
+	libxml_clear_errors();
+	if (!$loaded) {
+		return false;
+	}
+
+	$xpath = new DOMXPath($dom);
+
+	// Remove <script> elements.
+	foreach (iterator_to_array($xpath->query('//script')) as $node) {
+		$node->parentNode->removeChild($node);
+	}
+
+	// Remove <foreignObject> — can embed arbitrary HTML.
+	foreach (iterator_to_array($xpath->query('//foreignObject')) as $node) {
+		$node->parentNode->removeChild($node);
+	}
+
+	// Remove on* event attributes and javascript: URIs from every element.
+	foreach ($xpath->query('//*') as $element) {
+		$toRemove = array();
+		foreach ($element->attributes as $attr) {
+			$name  = strtolower($attr->name);
+			$value = strtolower(trim($attr->value));
+			if (strpos($name, 'on') === 0) {
+				$toRemove[] = $attr->name;
+			} elseif (in_array($name, array('href', 'xlink:href', 'action', 'src'), true)
+				&& strpos($value, 'javascript:') !== false) {
+				$toRemove[] = $attr->name;
+			}
+		}
+		foreach ($toRemove as $attrName) {
+			$element->removeAttribute($attrName);
+		}
+	}
+
+	// Remove <use> elements that reference external documents.
+	foreach (iterator_to_array($xpath->query('//use')) as $node) {
+		$href = $node->getAttribute('href');
+		if (empty($href)) {
+			$href = $node->getAttributeNS('http://www.w3.org/1999/xlink', 'href');
+		}
+		// Only allow same-document fragment references (#id).
+		if (!empty($href) && strpos($href, '#') !== 0) {
+			$node->parentNode->removeChild($node);
+		}
+	}
+
+	$sanitized = $dom->saveXML();
+	if ($sanitized === false) {
+		return false;
+	}
+
+	return file_put_contents($file, $sanitized) !== false;
+}
+
 function transformImage($file, $imageDir, $thumbnailDir = false)
 {
   global $site;
@@ -983,6 +1053,15 @@ function transformImage($file, $imageDir, $thumbnailDir = false)
   $image = $imageDir . $nextFilename;
   Filesystem::mv($file, $image);
   chmod($image, 0644);
+
+  // Sanitize SVG files to remove active content before storage.
+  if ($fileExtension === 'svg') {
+    if (sanitizeSVG($image) === false) {
+      Log::set('SVG sanitization failed (invalid XML), rejecting file: ' . $image, LOG_TYPE_ERROR);
+      @unlink($image);
+      return false;
+    }
+  }
 
   // Generate Thumbnail
   if (!empty($thumbnailDir) && $site->thumbnailEnable()) {

--- a/bl-kernel/functions.php
+++ b/bl-kernel/functions.php
@@ -970,36 +970,41 @@ function sanitizeSVG($file)
 
 	$xpath = new DOMXPath($dom);
 
-	// Remove <script> elements.
-	foreach (iterator_to_array($xpath->query('//script')) as $node) {
+	// Remove <script> elements. Use local-name() so namespaced SVG elements
+	// (xmlns="http://www.w3.org/2000/svg") are matched too.
+	foreach (iterator_to_array($xpath->query('//*[local-name()="script"]')) as $node) {
 		$node->parentNode->removeChild($node);
 	}
 
-	// Remove <foreignObject> — can embed arbitrary HTML.
-	foreach (iterator_to_array($xpath->query('//foreignObject')) as $node) {
+	// Remove <foreignObject> — can embed arbitrary HTML (namespace-agnostic).
+	foreach (iterator_to_array($xpath->query('//*[local-name()="foreignObject"]')) as $node) {
 		$node->parentNode->removeChild($node);
 	}
 
 	// Remove on* event attributes and javascript: URIs from every element.
+	// Collect the attribute nodes (not their names) and remove them with
+	// removeAttributeNode() so namespaced attributes such as xlink:href are
+	// handled — removeAttribute('href') cannot match a prefixed attribute,
+	// and PHP reports their ->name as the bare local name anyway.
 	foreach ($xpath->query('//*') as $element) {
 		$toRemove = array();
 		foreach ($element->attributes as $attr) {
-			$name  = strtolower($attr->name);
+			$name  = strtolower($attr->localName);
 			$value = strtolower(trim($attr->value));
 			if (strpos($name, 'on') === 0) {
-				$toRemove[] = $attr->name;
-			} elseif (in_array($name, array('href', 'xlink:href', 'action', 'src'), true)
+				$toRemove[] = $attr;
+			} elseif (in_array($name, array('href', 'action', 'formaction', 'src'), true)
 				&& strpos($value, 'javascript:') !== false) {
-				$toRemove[] = $attr->name;
+				$toRemove[] = $attr;
 			}
 		}
-		foreach ($toRemove as $attrName) {
-			$element->removeAttribute($attrName);
+		foreach ($toRemove as $attrNode) {
+			$element->removeAttributeNode($attrNode);
 		}
 	}
 
-	// Remove <use> elements that reference external documents.
-	foreach (iterator_to_array($xpath->query('//use')) as $node) {
+	// Remove <use> elements that reference external documents (namespace-agnostic).
+	foreach (iterator_to_array($xpath->query('//*[local-name()="use"]')) as $node) {
 		$href = $node->getAttribute('href');
 		if (empty($href)) {
 			$href = $node->getAttributeNS('http://www.w3.org/1999/xlink', 'href');


### PR DESCRIPTION
- Add sanitizeSVG() using DOMDocument/DOMXPath (no external dependencies)
- Strip <script>, <foreignObject>, on* event attributes, javascript: URIs, and <use> elements referencing external documents
- Call from transformImage() after file is moved; reject and delete the file if the SVG cannot be parsed as valid XML
- Symlink thumbnail inherits the sanitized file automatically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Enhanced SVG uploads: uploaded SVG files are now sanitized to remove embedded scripts, inline event handlers, and unsafe external references before storage and thumbnail generation.
  * If sanitization fails, the upload is rejected and the file is not saved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->