### PR TITLE
perf: read JSON db files with file_get_contents instead of file()+implode

### DIFF
--- a/bl-kernel/abstract/dbjson.class.php
+++ b/bl-kernel/abstract/dbjson.class.php
@@ -18,24 +18,24 @@ class dbJSON {
 
 		if (file_exists($file)) {
 			// Read JSON file
-			$lines = file($file);
+			$data = file_get_contents($file);
 
-			// Remove the first line, the first line is for security reasons
-			if ($firstLine) {
-				unset($lines[0]);
-			}
+			if ($data !== false) {
+				// Remove the first line, the first line is for security reasons
+				if ($firstLine) {
+					$newlinePos = strpos($data, "\n");
+					$data = ($newlinePos === false) ? '' : substr($data, $newlinePos + 1);
+				}
 
-			// Regenerate the JSON file
-			$implode = implode('', $lines);
-
-			// Unserialize, JSON to Array
-			$array = $this->unserialize($implode);
-			if (empty($array)) {
-				$this->db = array();
-				$this->dbBackup = array();
-			} else {
-				$this->db = $array;
-				$this->dbBackup = $array;
+				// Unserialize, JSON to Array
+				$array = $this->unserialize($data);
+				if (empty($array)) {
+					$this->db = array();
+					$this->dbBackup = array();
+				} else {
+					$this->db = $array;
+					$this->dbBackup = $array;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Avoids allocating a line array just to glue it back together.
No behavior change (verified against all core/plugin/language db files plus edge cases: empty files, missing trailing newline, CRLF headers, corrupted JSON).
Biggest gains are on multi-line files (language files, DEBUG_MODE db files); minified single-line prod db files are roughly a wash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading database-backed content.
  * Added safer handling for unreadable or unexpectedly formatted data files.
  * Prevented loading failures from disrupting normal application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->