### PR TITLE
chore: bump version to 4.0.0-beta-1

### DIFF
--- a/bl-kernel/boot/init.php
+++ b/bl-kernel/boot/init.php
@@ -1,10 +1,10 @@
 <?php defined('BLUDIT') or die('Bludit CMS.');
 
 // Bludit version
-define('BLUDIT_VERSION',        '4.0.0-beta');
+define('BLUDIT_VERSION',        '4.0.0-beta-1');
 define('BLUDIT_CODENAME',       '');
-define('BLUDIT_RELEASE_DATE',   '2026-07-23');
-define('BLUDIT_BUILD',          '20260723');
+define('BLUDIT_RELEASE_DATE',   '2026-08-15');
+define('BLUDIT_BUILD',          '20260815');
 
 // Change to TRUE for debugging
 define('DEBUG_MODE', FALSE);

--- a/bl-plugins/about/metadata.json
+++ b/bl-plugins/about/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.22.0",
-	"releaseDate": "2026-05-10",
+	"version": "4.0.0-beta-1",
+	"releaseDate": "2026-08-15",
 	"license": "MIT",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": ""
 }

--- a/bl-plugins/alternative/metadata.json
+++ b/bl-plugins/alternative/metadata.json
@@ -2,10 +2,10 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.22.0",
-	"releaseDate": "2026-05-10",
+	"version": "4.0.0-beta-1",
+	"releaseDate": "2026-08-15",
 	"license": "MIT",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": "",
 	"type": "theme"
 }

--- a/bl-plugins/api/metadata.json
+++ b/bl-plugins/api/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.22.0",
-	"releaseDate": "2026-05-10",
+	"version": "4.0.0-beta-1",
+	"releaseDate": "2026-08-15",
 	"license": "MIT",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": ""
 }

--- a/bl-plugins/canonical/metadata.json
+++ b/bl-plugins/canonical/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.22.0",
-	"releaseDate": "2026-05-10",
+	"version": "4.0.0-beta-1",
+	"releaseDate": "2026-08-15",
 	"license": "MIT",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": ""
 }

--- a/bl-plugins/categories/metadata.json
+++ b/bl-plugins/categories/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.22.0",
-	"releaseDate": "2026-05-10",
+	"version": "4.0.0-beta-1",
+	"releaseDate": "2026-08-15",
 	"license": "MIT",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": ""
 }

--- a/bl-plugins/custom-fields-parser/metadata.json
+++ b/bl-plugins/custom-fields-parser/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.22.0",
-	"releaseDate": "2026-05-10",
+	"version": "4.0.0-beta-1",
+	"releaseDate": "2026-08-15",
 	"license": "MIT",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": ""
 }

--- a/bl-plugins/disqus/metadata.json
+++ b/bl-plugins/disqus/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.22.0",
-	"releaseDate": "2026-05-10",
+	"version": "4.0.0-beta-1",
+	"releaseDate": "2026-08-15",
 	"license": "MIT",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": ""
 }

--- a/bl-plugins/easymde/metadata.json
+++ b/bl-plugins/easymde/metadata.json
@@ -5,6 +5,6 @@
 	"version": "2.18.0",
 	"releaseDate": "2022-09-20",
 	"license": "MIT",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": ""
 }

--- a/bl-plugins/hit-counter/metadata.json
+++ b/bl-plugins/hit-counter/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.22.0",
-	"releaseDate": "2026-05-10",
+	"version": "4.0.0-beta-1",
+	"releaseDate": "2026-08-15",
 	"license": "MIT",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": ""
 }

--- a/bl-plugins/html-code/metadata.json
+++ b/bl-plugins/html-code/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.22.0",
-	"releaseDate": "2026-05-10",
+	"version": "4.0.0-beta-1",
+	"releaseDate": "2026-08-15",
 	"license": "MIT",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": ""
 }

--- a/bl-plugins/links/metadata.json
+++ b/bl-plugins/links/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.22.0",
-	"releaseDate": "2026-05-10",
+	"version": "4.0.0-beta-1",
+	"releaseDate": "2026-08-15",
 	"license": "MIT",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": ""
 }

--- a/bl-plugins/maintenance-mode/metadata.json
+++ b/bl-plugins/maintenance-mode/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.22.0",
-	"releaseDate": "2026-05-10",
+	"version": "4.0.0-beta-1",
+	"releaseDate": "2026-08-15",
 	"license": "MIT",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": ""
 }

--- a/bl-plugins/navigation/metadata.json
+++ b/bl-plugins/navigation/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.22.0",
-	"releaseDate": "2026-05-10",
+	"version": "4.0.0-beta-1",
+	"releaseDate": "2026-08-15",
 	"license": "MIT",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": ""
 }

--- a/bl-plugins/opengraph/metadata.json
+++ b/bl-plugins/opengraph/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.22.0",
-	"releaseDate": "2026-05-10",
+	"version": "4.0.0-beta-1",
+	"releaseDate": "2026-08-15",
 	"license": "MIT",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": ""
 }

--- a/bl-plugins/remote-content/metadata.json
+++ b/bl-plugins/remote-content/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com/plugin/remote-content",
-	"version": "3.22.0",
-	"releaseDate": "2026-05-10",
+	"version": "4.0.0-beta-1",
+	"releaseDate": "2026-08-15",
 	"license": "MIT",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": ""
 }

--- a/bl-plugins/robots/metadata.json
+++ b/bl-plugins/robots/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.22.0",
-	"releaseDate": "2026-05-10",
+	"version": "4.0.0-beta-1",
+	"releaseDate": "2026-08-15",
 	"license": "MIT",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": ""
 }

--- a/bl-plugins/rss/metadata.json
+++ b/bl-plugins/rss/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.22.0",
-	"releaseDate": "2026-05-10",
+	"version": "4.0.0-beta-1",
+	"releaseDate": "2026-08-15",
 	"license": "MIT",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": ""
 }

--- a/bl-plugins/search/metadata.json
+++ b/bl-plugins/search/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.22.0",
-	"releaseDate": "2026-05-10",
+	"version": "4.0.0-beta-1",
+	"releaseDate": "2026-08-15",
 	"license": "MIT",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": ""
 }

--- a/bl-plugins/sitemap/metadata.json
+++ b/bl-plugins/sitemap/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.22.0",
-	"releaseDate": "2026-05-10",
+	"version": "4.0.0-beta-1",
+	"releaseDate": "2026-08-15",
 	"license": "MIT",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": ""
 }

--- a/bl-plugins/static-pages/metadata.json
+++ b/bl-plugins/static-pages/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.22.0",
-	"releaseDate": "2026-05-10",
+	"version": "4.0.0-beta-1",
+	"releaseDate": "2026-08-15",
 	"license": "MIT",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": ""
 }

--- a/bl-plugins/tags/metadata.json
+++ b/bl-plugins/tags/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.22.0",
-	"releaseDate": "2026-05-10",
+	"version": "4.0.0-beta-1",
+	"releaseDate": "2026-08-15",
 	"license": "MIT",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": ""
 }

--- a/bl-plugins/tinymce/metadata.json
+++ b/bl-plugins/tinymce/metadata.json
@@ -5,6 +5,6 @@
 	"version": "8.3.2",
 	"releaseDate": "2026-01-14",
 	"license": "GPL 2.0+",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": ""
 }

--- a/bl-plugins/twitter-cards/metadata.json
+++ b/bl-plugins/twitter-cards/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.22.0",
-	"releaseDate": "2026-05-10",
+	"version": "4.0.0-beta-1",
+	"releaseDate": "2026-08-15",
 	"license": "MIT",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": ""
 }

--- a/bl-plugins/version/metadata.json
+++ b/bl-plugins/version/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.22.0",
-	"releaseDate": "2026-05-10",
+	"version": "4.0.0-beta-1",
+	"releaseDate": "2026-08-15",
 	"license": "MIT",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": ""
 }

--- a/bl-plugins/visits-stats/metadata.json
+++ b/bl-plugins/visits-stats/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://plugins.bludit.com",
-	"version": "3.22.0",
-	"releaseDate": "2026-05-10",
+	"version": "4.0.0-beta-1",
+	"releaseDate": "2026-08-15",
 	"license": "MIT",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": ""
 }

--- a/bl-themes/alternative/metadata.json
+++ b/bl-themes/alternative/metadata.json
@@ -2,10 +2,10 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://themes.bludit.com",
-	"version": "3.22.0",
-	"releaseDate": "2026-05-10",
+	"version": "4.0.0-beta-1",
+	"releaseDate": "2026-08-15",
 	"license": "MIT",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": "Improved accessibility, SEO with Schema.org, responsive design, and performance",
 	"plugin": "alternative"
 }

--- a/bl-themes/blogx/metadata.json
+++ b/bl-themes/blogx/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://themes.bludit.com",
-	"version": "3.22.0",
-	"releaseDate": "2026-05-10",
+	"version": "4.0.0-beta-1",
+	"releaseDate": "2026-08-15",
 	"license": "MIT",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": ""
 }

--- a/bl-themes/flavor/metadata.json
+++ b/bl-themes/flavor/metadata.json
@@ -2,9 +2,9 @@
 	"author": "Bludit",
 	"email": "",
 	"website": "https://themes.bludit.com",
-	"version": "3.22.0",
-	"releaseDate": "2026-05-10",
+	"version": "4.0.0-beta-1",
+	"releaseDate": "2026-08-15",
 	"license": "MIT",
-	"compatible": "3.22",
+	"compatible": "4.0",
 	"notes": ""
 }


### PR DESCRIPTION
## Summary
- Bump `BLUDIT_VERSION` to `4.0.0-beta-1`, following the project's historical pre-release naming convention (e.g. `3.0.0-beta-1`)
- Update `BLUDIT_RELEASE_DATE` and `BLUDIT_BUILD` in `bl-kernel/boot/init.php`
- Sync `version`, `releaseDate`, and `compatible` in every first-party plugin/theme `metadata.json` under `bl-plugins/` and `bl-themes/`
- Bump `compatible` (only) in the vendor-versioned `easymde` and `tinymce` plugin metadata, since those track their own upstream library versions

## Test plan
- [x] `php -l bl-kernel/boot/init.php` passes
- [x] All modified `metadata.json` files validated as well-formed JSON


---
_Generated by [Claude Code](https://claude.ai/code/session_015xewjsAQXD5MDhhB4uSFkS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the product release to **4.0.0-beta-1**, dated **August 15, 2026**.
  - Updated the listed plugins and themes for compatibility with **Bludit 4.0**.
  - Refreshed plugin and theme version metadata to match the new beta release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->