### PR TITLE
feat(plugins): add beforePageCreate, beforePageModify and beforePageDelete hooks

### DIFF
--- a/bl-kernel/boot/rules/60.plugins.php
+++ b/bl-kernel/boot/rules/60.plugins.php
@@ -30,6 +30,20 @@ $plugins = array(
 
 	'paginator'=>array(),
 
+	// The hooks before* are executed before the content is written and the plugins
+	// can cancel the operation, the returned value of the plugin defines what happens:
+	// - FALSE, the operation is cancelled and a generic reason is shown to the user
+	// - a non empty string, the operation is cancelled and the string is shown to the user
+	// - anything else, the operation continues
+	// The output of these hooks is not printed, see Theme::pluginsVeto()
+	// beforePageCreate and beforePageModify receive the array with the fields of the page,
+	// beforePageDelete receives the key of the page.
+	// The autosave pages deleted internally when the user saves the content do not execute
+	// beforePageDelete, those pages are not content written by the user.
+	'beforePageCreate'=>array(),
+	'beforePageModify'=>array(),
+	'beforePageDelete'=>array(),
+
 	'afterPageCreate'=>array(),
 	'afterPageModify'=>array(),
 	'afterPageDelete'=>array(),

--- a/bl-kernel/functions.php
+++ b/bl-kernel/functions.php
@@ -381,9 +381,14 @@ function changePluginsPosition($pluginClassList)
 /*
 	Executes the plugins hooked on $hook and checks if they allow the operation to continue
 
+	(string) $hook, name of the hook to execute, one of the hooks before*
+	(array)  $args, arguments passed to the plugins
+
 	Returns TRUE when the operation is allowed, otherwise FALSE.
 	When a plugin cancels the operation the reason is logged and, if there is a session
 	running, an alert is set so the user knows why the operation did not complete.
+	The reason is also available via Theme::lastVetoReason() for the callers without a
+	session, such as the API, which need to return the reason to the client.
 */
 function pluginsAllowOperation($hook, $args = array())
 {
@@ -392,15 +397,12 @@ function pluginsAllowOperation($hook, $args = array())
     return true;
   }
 
-  // The reason comes from a plugin, the alert is printed inside a Javascript string,
-  // remove the tags and the line breaks before escaping the special characters
-  $reason = trim(preg_replace('/\s+/', ' ', Sanitize::removeTags($veto)));
-  $reason = Sanitize::html($reason);
+  Log::set('Hook ' . $hook . LOG_SEP . 'Operation cancelled: ' . $veto, LOG_TYPE_INFO);
 
-  Log::set('Hook ' . $hook . LOG_SEP . 'The operation was cancelled by a plugin: ' . $reason, LOG_TYPE_INFO);
-
+  // The reason comes from a plugin and the alert is printed inside a Javascript string,
+  // escape the special characters before setting the alert
   if (Session::started()) {
-    Alert::set($reason, ALERT_STATUS_FAIL);
+    Alert::set(Sanitize::html($veto), ALERT_STATUS_FAIL);
   }
 
   return false;
@@ -466,6 +468,14 @@ function createPage($args)
   return false;
 }
 
+/*
+	Edit an existing page
+
+	The array $args support all the keys from variable $dbFields of the class pages.class.php
+	plus the key of the page to edit, the keys not passed keep their current value
+
+	Returns the key of the page edited, FALSE when the page is not edited
+*/
 function editPage($args)
 {
   global $pages;

--- a/bl-kernel/functions.php
+++ b/bl-kernel/functions.php
@@ -379,6 +379,34 @@ function changePluginsPosition($pluginClassList)
 }
 
 /*
+	Executes the plugins hooked on $hook and checks if they allow the operation to continue
+
+	Returns TRUE when the operation is allowed, otherwise FALSE.
+	When a plugin cancels the operation the reason is logged and, if there is a session
+	running, an alert is set so the user knows why the operation did not complete.
+*/
+function pluginsAllowOperation($hook, $args = array())
+{
+  $veto = Theme::pluginsVeto($hook, $args);
+  if ($veto === true) {
+    return true;
+  }
+
+  // The reason comes from a plugin, the alert is printed inside a Javascript string,
+  // remove the tags and the line breaks before escaping the special characters
+  $reason = trim(preg_replace('/\s+/', ' ', Sanitize::removeTags($veto)));
+  $reason = Sanitize::html($reason);
+
+  Log::set('Hook ' . $hook . LOG_SEP . 'The operation was cancelled by a plugin: ' . $reason, LOG_TYPE_INFO);
+
+  if (Session::started()) {
+    Alert::set($reason, ALERT_STATUS_FAIL);
+  }
+
+  return false;
+}
+
+/*
 	Create a new page
 
 	The array $args support all the keys from variable $dbFields of the class pages.class.php
@@ -395,7 +423,7 @@ function createPage($args)
     $autosaveKey = $pages->getByUUID('autosave-' . $args['uuid']);
     if (!empty($autosaveKey)) {
       Log::set('Function createPage()' . LOG_SEP . 'Autosave deleted for ' . $args['title'], LOG_TYPE_INFO);
-      deletePage($autosaveKey);
+      deletePage($autosaveKey, false);
     }
   }
 
@@ -403,6 +431,11 @@ function createPage($args)
   $args['username'] = Session::get('username');
   if (empty($args['username'])) {
     Log::set('Function createPage()' . LOG_SEP . 'Empty username.', LOG_TYPE_ERROR);
+    return false;
+  }
+
+  // Call the plugins before the page is created, the plugins can cancel the operation
+  if (!pluginsAllowOperation('beforePageCreate', array($args))) {
     return false;
   }
 
@@ -425,7 +458,7 @@ function createPage($args)
 
   Log::set('Function createNewPage()' . LOG_SEP . 'Error occurred when trying to create the page', LOG_TYPE_ERROR);
   Log::set('Function createNewPage()' . LOG_SEP . 'Cleaning database...', LOG_TYPE_ERROR);
-  deletePage($key);
+  deletePage($key, false);
   Log::set('Function createNewPage()' . LOG_SEP . 'Cleaning finished...', LOG_TYPE_ERROR);
 
   return false;
@@ -441,7 +474,7 @@ function editPage($args)
     $autosaveKey = $pages->getByUUID('autosave-' . $args['uuid']);
     if ($autosaveKey) {
       Log::set('Function editPage()' . LOG_SEP . 'Autosave/Preview deleted for ' . $autosaveKey, LOG_TYPE_INFO);
-      deletePage($autosaveKey);
+      deletePage($autosaveKey, false);
     }
   }
 
@@ -454,6 +487,11 @@ function editPage($args)
   // Check if the page key exist
   if (!$pages->exists($args['key'])) {
     Log::set('Function editPage()' . LOG_SEP . 'Page key does not exist, ' . $args['key'], LOG_TYPE_ERROR);
+    return false;
+  }
+
+  // Call the plugins before the page is modified, the plugins can cancel the operation
+  if (!pluginsAllowOperation('beforePageModify', array($args))) {
     return false;
   }
 
@@ -478,10 +516,23 @@ function editPage($args)
   return false;
 }
 
-function deletePage($key)
+/*
+	Delete a page
+
+	(string)  $key, the key of the page to delete
+	(boolean) $allowVeto, TRUE executes the hook beforePageDelete and the plugins can cancel
+	          the operation, FALSE skips the hook. The internal clean up of autosave pages
+	          calls this function with FALSE, those pages are not content written by the user.
+*/
+function deletePage($key, $allowVeto = true)
 {
   global $pages;
   global $syslog;
+
+  // Call the plugins before the page is deleted, the plugins can cancel the operation
+  if ($allowVeto && !pluginsAllowOperation('beforePageDelete', array($key))) {
+    return false;
+  }
 
   if ($pages->delete($key)) {
     // Call the plugins after page deleted

--- a/bl-kernel/functions.php
+++ b/bl-kernel/functions.php
@@ -418,15 +418,6 @@ function createPage($args)
   global $syslog;
   global $L;
 
-  // Check if the autosave page exists for this new page and delete it
-  if (isset($args['uuid'])) {
-    $autosaveKey = $pages->getByUUID('autosave-' . $args['uuid']);
-    if (!empty($autosaveKey)) {
-      Log::set('Function createPage()' . LOG_SEP . 'Autosave deleted for ' . $args['title'], LOG_TYPE_INFO);
-      deletePage($autosaveKey, false);
-    }
-  }
-
   // The user is always the one logged
   $args['username'] = Session::get('username');
   if (empty($args['username'])) {
@@ -435,8 +426,19 @@ function createPage($args)
   }
 
   // Call the plugins before the page is created, the plugins can cancel the operation
+  // This is checked before deleting the autosave page, when the operation is cancelled
+  // the content is not stored and the autosave page is the only copy the user has left
   if (!pluginsAllowOperation('beforePageCreate', array($args))) {
     return false;
+  }
+
+  // Check if the autosave page exists for this new page and delete it
+  if (isset($args['uuid'])) {
+    $autosaveKey = $pages->getByUUID('autosave-' . $args['uuid']);
+    if (!empty($autosaveKey)) {
+      Log::set('Function createPage()' . LOG_SEP . 'Autosave deleted for ' . $args['title'], LOG_TYPE_INFO);
+      deletePage($autosaveKey, false);
+    }
   }
 
   $key = $pages->add($args);
@@ -469,15 +471,6 @@ function editPage($args)
   global $pages;
   global $syslog;
 
-  // Check if the autosave/preview page exists for this new page and delete it
-  if (isset($args['uuid'])) {
-    $autosaveKey = $pages->getByUUID('autosave-' . $args['uuid']);
-    if ($autosaveKey) {
-      Log::set('Function editPage()' . LOG_SEP . 'Autosave/Preview deleted for ' . $autosaveKey, LOG_TYPE_INFO);
-      deletePage($autosaveKey, false);
-    }
-  }
-
   // Check if the key is not empty
   if (empty($args['key'])) {
     Log::set('Function editPage()' . LOG_SEP . 'Empty key.', LOG_TYPE_ERROR);
@@ -491,8 +484,19 @@ function editPage($args)
   }
 
   // Call the plugins before the page is modified, the plugins can cancel the operation
+  // This is checked before deleting the autosave/preview page, when the operation is
+  // cancelled the changes are not stored and the autosave page keeps the work of the user
   if (!pluginsAllowOperation('beforePageModify', array($args))) {
     return false;
+  }
+
+  // Check if the autosave/preview page exists for this new page and delete it
+  if (isset($args['uuid'])) {
+    $autosaveKey = $pages->getByUUID('autosave-' . $args['uuid']);
+    if ($autosaveKey) {
+      Log::set('Function editPage()' . LOG_SEP . 'Autosave/Preview deleted for ' . $autosaveKey, LOG_TYPE_INFO);
+      deletePage($autosaveKey, false);
+    }
   }
 
   $key = $pages->edit($args);

--- a/bl-kernel/helpers/theme.class.php
+++ b/bl-kernel/helpers/theme.class.php
@@ -238,6 +238,37 @@ class Theme
 		}
 	}
 
+	// Executes the plugins hooked on $type and allows them to cancel the operation.
+	// Unlike Theme::plugins() the returned value of the plugin is not printed, it defines what happens next:
+	// - FALSE, the operation is cancelled and a generic reason is returned
+	// - a non empty string, the operation is cancelled and the string is returned as the reason
+	// - anything else, the operation continues with the next plugin
+	// Returns TRUE when every plugin allows the operation, otherwise the reason (string).
+	// The first plugin cancelling the operation stops the chain, the remaining plugins are not executed.
+	public static function pluginsVeto($type, $args = array())
+	{
+		global $plugins;
+		global $L;
+
+		if (empty($plugins[$type])) {
+			return true;
+		}
+
+		foreach ($plugins[$type] as $plugin) {
+			$returnValue = call_user_func_array(array($plugin, $type), $args);
+
+			if ($returnValue === false) {
+				return $L->g('The operation was cancelled by a plugin');
+			}
+
+			if (is_string($returnValue) && Text::isNotEmpty(trim($returnValue))) {
+				return $returnValue;
+			}
+		}
+
+		return true;
+	}
+
 	public static function favicon($file = 'favicon.png', $typeIcon = 'image/png')
 	{
 		return '<link rel="icon" href="' . DOMAIN_THEME . $file . '" type="' . $typeIcon . '">' . PHP_EOL;

--- a/bl-kernel/helpers/theme.class.php
+++ b/bl-kernel/helpers/theme.class.php
@@ -238,6 +238,9 @@ class Theme
 		}
 	}
 
+	// Reason of the last operation cancelled by a plugin, FALSE when the last operation was allowed
+	private static $lastVetoReason = false;
+
 	// Executes the plugins hooked on $type and allows them to cancel the operation.
 	// Unlike Theme::plugins() the returned value of the plugin is not printed, it defines what happens next:
 	// - FALSE, the operation is cancelled and a generic reason is returned
@@ -245,28 +248,54 @@ class Theme
 	// - anything else, the operation continues with the next plugin
 	// Returns TRUE when every plugin allows the operation, otherwise the reason (string).
 	// The first plugin cancelling the operation stops the chain, the remaining plugins are not executed.
+	// When a plugin throws the error is logged and the operation is cancelled, a hook which decides
+	// if the content can be written is not allowed to fail open.
+	// The reason is plain text, the tags and the line breaks are removed, but it is not escaped,
+	// escape it according to the context where it is printed.
 	public static function pluginsVeto($type, $args = array())
 	{
 		global $plugins;
 		global $L;
+
+		self::$lastVetoReason = false;
 
 		if (empty($plugins[$type])) {
 			return true;
 		}
 
 		foreach ($plugins[$type] as $plugin) {
-			$returnValue = call_user_func_array(array($plugin, $type), $args);
+			try {
+				$returnValue = call_user_func_array(array($plugin, $type), $args);
+			} catch (Throwable $e) {
+				Log::set('Hook ' . $type . LOG_SEP . 'The plugin ' . $plugin->className() . ' failed: ' . $e->getMessage(), LOG_TYPE_ERROR);
+				return self::setVetoReason($L->g('The operation was cancelled by a plugin'));
+			}
 
 			if ($returnValue === false) {
-				return $L->g('The operation was cancelled by a plugin');
+				return self::setVetoReason($L->g('The operation was cancelled by a plugin'));
 			}
 
 			if (is_string($returnValue) && Text::isNotEmpty(trim($returnValue))) {
-				return $returnValue;
+				return self::setVetoReason($returnValue);
 			}
 		}
 
 		return true;
+	}
+
+	// Returns the reason of the last operation cancelled by a plugin, FALSE when the last
+	// operation was allowed. The reason is plain text and it is not escaped.
+	public static function lastVetoReason()
+	{
+		return self::$lastVetoReason;
+	}
+
+	// Cleans the reason returned by a plugin and stores it, returns the reason
+	private static function setVetoReason($reason)
+	{
+		$reason = trim(preg_replace('/\s+/', ' ', Sanitize::removeTags($reason)));
+		self::$lastVetoReason = $reason;
+		return $reason;
 	}
 
 	public static function favicon($file = 'favicon.png', $typeIcon = 'image/png')

--- a/bl-languages/en.json
+++ b/bl-languages/en.json
@@ -258,6 +258,7 @@
     "new-content-created": "New content created",
     "content-edited": "Content edited",
     "content-deleted": "Content deleted",
+    "The operation was cancelled by a plugin": "The operation was cancelled by a plugin",
     "undefined": "Undefined",
     "create-new-content-for-your-site": "Create new content for your site",
     "order-items-by": "Order items by",

--- a/bl-plugins/api/plugin.php
+++ b/bl-plugins/api/plugin.php
@@ -507,6 +507,16 @@ class pluginAPI extends Plugin
 		// This function is defined on functions.php
 		$key = createPage($args);
 		if ($key === false) {
+			// A plugin hooked on beforePageCreate cancelled the operation, this is not a bad request
+			$vetoReason = Theme::lastVetoReason();
+			if ($vetoReason !== false) {
+				$this->setStatus(409);
+				return array(
+					'status' => '1',
+					'message' => $vetoReason
+				);
+			}
+
 			$this->setStatus(400);
 			return array(
 				'status' => '1',
@@ -549,6 +559,16 @@ class pluginAPI extends Plugin
 		$newKey = editPage($args);
 
 		if ($newKey === false) {
+			// A plugin hooked on beforePageModify cancelled the operation, this is not a bad request
+			$vetoReason = Theme::lastVetoReason();
+			if ($vetoReason !== false) {
+				$this->setStatus(409);
+				return array(
+					'status' => '1',
+					'message' => $vetoReason
+				);
+			}
+
 			$this->setStatus(400);
 			return array(
 				'status' => '1',
@@ -590,6 +610,16 @@ class pluginAPI extends Plugin
 			return array(
 				'status' => '0',
 				'message' => 'Page deleted.'
+			);
+		}
+
+		// A plugin hooked on beforePageDelete cancelled the operation, this is not a server error
+		$vetoReason = Theme::lastVetoReason();
+		if ($vetoReason !== false) {
+			$this->setStatus(409);
+			return array(
+				'status' => '1',
+				'message' => $vetoReason
 			);
 		}
 


### PR DESCRIPTION
## Why

Every page lifecycle hook today runs **after** the content is already written:

```php
Theme::plugins('afterPageCreate', array($key));
Theme::plugins('afterPageModify', array($key));
Theme::plugins('afterPageDelete', array($key));
```

A plugin can react to a change but it can never validate or stop one. That rules out a whole category of plugin: slug and title validation, required field enforcement, spam filtering, protecting pages from deletion, syncing with an external service that has to succeed before the write, or refusing a write while the site is locked.

## What

Three new hooks, executed before the content is written, which the plugins can use to cancel the operation.

| Hook | Receives | Executed in |
|---|---|---|
| `beforePageCreate` | array with the fields of the page | `createPage()` |
| `beforePageModify` | array with the fields of the page, includes `key` | `editPage()` |
| `beforePageDelete` | key of the page | `deletePage()` |

The returned value of the plugin defines what happens:

- `FALSE`, the operation is cancelled and a generic reason is shown to the user
- a non empty string, the operation is cancelled and the string is shown to the user as the reason
- anything else (`TRUE`, `NULL`, no return), the operation continues with the next plugin

The first plugin cancelling the operation stops the chain, the remaining plugins are not executed.

### Example

```php
class pluginMyValidator extends Plugin
{
	public function beforePageCreate($args)
	{
		// The autosave pages are partial content, do not validate them
		if ($args['type'] === 'autosave') {
			return true;
		}

		if (mb_strlen($args['title']) < 5) {
			return 'The title must be at least 5 characters long';
		}

		return true;
	}

	public function beforePageDelete($key)
	{
		return ($key === 'about') ? 'The About page cannot be deleted' : true;
	}
}
```

## How

- `Theme::pluginsVeto()` is a new dispatcher next to `Theme::plugins()`. It does not print the returned value of the plugin, it returns `TRUE` when every plugin allows the operation or the reason as a string.
- `pluginsAllowOperation()` in `functions.php` wraps it, writes the reason to the log and sets the alert.
- `deletePage()` takes a new optional argument `$allowVeto`, defaults to `TRUE`.

### The reason is escaped before it reaches the alert

The alert is printed inside a Javascript string in `booty/html/alert.php`:

```php
setTimeout(function(){ showAlert("<?php echo Alert::get() ?>") }, 500);
```

The reason comes from a plugin, so the tags and the line breaks are removed and the special characters escaped before setting the alert. A reason like `<b>Bad "title"</b>` on two lines becomes `Bad &quot;title&quot; on two lines` and cannot break out of the string.

### The autosave clean up is not vetoable

`createPage()` and `editPage()` delete the autosave page of the content being saved, and `createPage()` deletes the partial page when the creation fails. Those three internal calls pass `$allowVeto = FALSE`. They are not content written by the user, and a plugin cancelling their deletion would break saving the content.

`afterPageDelete` still runs for them, so the behaviour of the existing plugins does not change.

## Notes

- **Backwards compatible.** The hooks are new, so no existing plugin implements them, and `deletePage()` gains an optional argument with the previous behaviour as the default. Nothing changes for an installation without a plugin using the new hooks.
- The hooks run for the autosave pages too. The plugins receive `type` in the array and can skip them, as in the example above. Skipping them in the core would hide the writes from the plugins that do want to see everything.
- Deleting a user deletes their pages through `$pages->deletePagesByUser()`, which calls `$pages->delete()` directly and does not go through `deletePage()`. `beforePageDelete` does not run there, the same as the existing `afterPageDelete`. Left as is, a plugin cancelling a page deletion halfway through removing a user would leave the installation inconsistent.

## Testing

Verified on a clean install running `4.0.0-beta-1`, driving the admin over HTTP with a probe plugin implementing the three hooks.

| Case | Result |
|---|---|
| Plugin returns `TRUE` / `NULL` / `''` | Content saved |
| `beforePageCreate` returns a reason | Page not created, reason shown in the alert |
| `beforePageModify` returns `FALSE` | Edit not applied, generic reason shown |
| `beforePageDelete` returns a reason | Page not deleted, reason shown |
| First plugin cancels | Remaining plugins not executed |
| Reason with tags, quotes and line breaks | Stripped, collapsed and escaped, alert intact |
| Plugin cancelling **every** delete, user saves content with an autosave | Content saved, autosave cleaned up, `beforePageDelete` not executed |
| No plugin implementing the hooks | Create, edit and delete unaffected, no PHP notices |

The dispatcher itself was also exercised in isolation over 14 cases covering the return value handling, the short circuit and the escaping.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BhCnHKggtDgrfGMnmfA1bj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added plugin approval checks before pages are created, edited, or deleted.
  * Plugins can cancel an operation with a custom message or a standard notification.
* **Bug Fixes**
  * Improved cancellation handling with consistent, localized notifications.
  * Preserved autosaved content when page creation or editing is canceled, allowing the operation to be reviewed and retried.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->