### PR TITLE
fix: back to plugins page after activating a plugin

### DIFF
--- a/bl-kernel/admin/controllers/install-plugin.php
+++ b/bl-kernel/admin/controllers/install-plugin.php
@@ -26,14 +26,5 @@ if (!activatePlugin($pluginClassName)) {
 	Log::set('Fail when try to activate the plugin.', LOG_TYPE_ERROR);
 }
 
-if (isset($plugins['all'][$pluginClassName])) {
-	$plugin = $plugins['all'][$pluginClassName];
-} else {
-	Redirect::page('plugins');
-}
-
-if (method_exists($plugin, 'form')) {
-	Redirect::page('configure-plugin/'.$pluginClassName);
-}
-
+// Go back to the plugins page, the alert with the result is set by activatePlugin()
 Redirect::page('plugins#'.$pluginClassName);

--- a/bl-kernel/admin/themes/booty/css/bludit.css
+++ b/bl-kernel/admin/themes/booty/css/bludit.css
@@ -830,14 +830,14 @@ select:focus,
 
 /* Highlight the table row pointed by the URL anchor, e.g. after activating a plugin */
 .table > tbody > tr:target > td {
-	animation: rowHighlight 2.5s ease-out forwards;
+	animation: row-highlight 2.5s ease-out forwards;
 }
 
 .table > tbody > tr:target {
 	scroll-margin-top: 20px;
 }
 
-@keyframes rowHighlight {
+@keyframes row-highlight {
 	0%, 40% {
 		box-shadow: inset 0 0 0 9999px rgba(22, 163, 74, 0.18);
 	}

--- a/bl-kernel/admin/themes/booty/css/bludit.css
+++ b/bl-kernel/admin/themes/booty/css/bludit.css
@@ -827,3 +827,29 @@ select:focus,
 	box-shadow: none !important;
 	outline: none !important;
 }
+
+/* Highlight the table row pointed by the URL anchor, e.g. after activating a plugin */
+.table > tbody > tr:target > td {
+	animation: rowHighlight 2.5s ease-out forwards;
+}
+
+.table > tbody > tr:target {
+	scroll-margin-top: 20px;
+}
+
+@keyframes rowHighlight {
+	0%, 40% {
+		box-shadow: inset 0 0 0 9999px rgba(22, 163, 74, 0.18);
+	}
+
+	100% {
+		box-shadow: inset 0 0 0 9999px rgba(22, 163, 74, 0);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.table > tbody > tr:target > td {
+		animation: none;
+		box-shadow: inset 0 0 0 9999px rgba(22, 163, 74, 0.18);
+	}
+}


### PR DESCRIPTION
### Problem

When a plugin is activated from the plugins page, Bludit redirects to `configure-plugin/<PluginClassName>` whenever the plugin implements a `form()` method. The user asked to activate a plugin, not to configure it, so being dropped into a settings form is unexpected and the plugins list is left behind with no confirmation that anything happened.

### Changes

- `install-plugin.php` now always redirects back to `plugins#<PluginClassName>` after activation. The `Plugin activated` alert was already being set by `installPlugin()`, so the plugins page now shows it. The `Settings` link stays on the plugin row for anyone who does want to configure it.
- Removed the redundant `isset($plugins['all'][...])` guard, since after the change both paths lead to the same page.
- Added a CSS `:target` rule so the row pointed by the URL anchor is highlighted with a soft green tint that holds briefly and then fades out, making it obvious which plugin was just enabled.

### Notes

The highlight uses `box-shadow: inset 0 0 0 9999px ...` instead of `background-color`, because Bootstrap 5.3 table cells paint their own `background-color: var(--bs-table-bg)` over anything set on the `<tr>`. This is the same mechanism Bootstrap uses for its own row states. A `prefers-reduced-motion` fallback keeps a static tint instead of the fade.

The rule targets `.table > tbody > tr:target`, so it is not plugin specific: any admin table whose rows carry an `id` gets the same behaviour when linked with an anchor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - After activating a plugin, you’re now taken directly to the Plugins page with the activated plugin highlighted.
  - The page automatically positions the highlighted plugin in view for easier identification.
  - Highlighting includes an animation, with a static highlight shown when reduced-motion preferences are enabled.
  - The updated navigation provides a more consistent activation experience and makes the result of activation easier to confirm.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->