### PR TITLE
feat: add plugins heading to the admin sidebar

### DIFF
--- a/bl-kernel/admin/themes/booty/html/sidebar.php
+++ b/bl-kernel/admin/themes/booty/html/sidebar.php
@@ -60,7 +60,7 @@
 
 		<?php
 			if (!empty($plugins['adminSidebar'])) {
-				echo '<li class="nav-item"><hr></li>';
+				echo '<li class="nav-item mt-3"><h4>' . $L->g('plugins') . '</h4></li>';
 				foreach ($plugins['adminSidebar'] as $pluginSidebar) {
 					echo '<li class="nav-item">';
 					echo $pluginSidebar->adminSidebar();


### PR DESCRIPTION
### Problem

Plugins that add an entry to the admin sidebar are rendered after a bare `<hr>` separator. The separator gives no indication of what the links below it are, and it is inconsistent with the rest of the sidebar, where every group is introduced by a heading.

### Changes

- Replace the `<hr>` above the plugin links with a `Plugins` heading, using the same `<li class="nav-item mt-3"><h4>` markup as the existing `Manage` and `Settings` sections.

The heading is only rendered when at least one plugin actually hooks into `adminSidebar`, so installs without such plugins are unaffected.

### Notes

The label reuses the existing `plugins` dictionary key, so it is already translated in every shipped language.

| Before | After |
| --- | --- |
| `Themes` → `───────` → plugin links | `Themes` → **Plugins** → plugin links |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Replaced the horizontal divider in the admin sidebar’s plugin section with a localized “Plugins” heading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->