### PR TITLE
API: accept the token on the Authorization header, handle CORS preflight

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -12,8 +12,10 @@ RewriteBase /
 RewriteRule ^bl-content/(databases|workspaces|pages|tmp)/.*$ - [R=404,L]
 
 # All URL process by index.php
+# The Authorization header is forwarded, Apache doesn't pass it to PHP by
+# default and the API reads the token from it
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
-RewriteRule ^(.*) index.php [PT,L]
+RewriteRule ^(.*) index.php [PT,L,E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 
 </IfModule>

--- a/bl-plugins/api/languages/en.json
+++ b/bl-plugins/api/languages/en.json
@@ -7,5 +7,7 @@
 	"api-token": "API Token",
 	"amount-of-pages": "Amount of pages",
 	"this-is-the-maximum-of-pages-to-return-when-you-call-to": "This is the maximum of pages to return when you call to /api/pages",
-	"this-token-is-for-read-only-and-is-regenerated-every-time-you-install-the-plugin": "This token is for read only and is regenerated every time you install the plugin"
+	"this-token-is-for-read-only-and-is-regenerated-every-time-you-install-the-plugin": "This token is for read only and is regenerated every time you install the plugin",
+	"allowed-origins": "Allowed origins",
+	"comma-separated-list-of-origins-allowed-to-call-the-api-from-a-browser": "Comma separated list of origins allowed to call the API from a browser, for example https://example.com. Use * to allow any origin"
 }

--- a/bl-plugins/api/plugin.php
+++ b/bl-plugins/api/plugin.php
@@ -34,7 +34,8 @@ class pluginAPI extends Plugin
 
 		$this->dbFields = array(
 			'token' => $token,	// API Token
-			'numberOfItems' => 15	// Amount of items to return
+			'numberOfItems' => 15,	// Amount of items to return
+			'allowedOrigins' => '*'	// Comma separated list of origins allowed by CORS, * allows any origin
 		);
 	}
 
@@ -68,6 +69,12 @@ class pluginAPI extends Plugin
 		$html .= '<span class="tip">' . $L->get('This is the maximum of pages to return when you call to') . '</span>';
 		$html .= '</div>';
 
+		$html .= '<div>';
+		$html .= '<label>' . $L->get('Allowed origins') . '</label>';
+		$html .= '<input name="allowedOrigins" type="text" dir="auto" value="' . $this->getValue('allowedOrigins') . '">';
+		$html .= '<span class="tip">' . $L->get('Comma separated list of origins allowed to call the API from a browser') . '</span>';
+		$html .= '</div>';
+
 		return $html;
 	}
 
@@ -96,12 +103,19 @@ class pluginAPI extends Plugin
 		// ------------------------------------------------------------
 		$method = $this->getMethod();
 
+		// CORS PREFLIGHT
+		// ------------------------------------------------------------
+		// The preflight request never carries credentials, it must be answered
+		// before any token check
+		if ($method === 'OPTIONS') {
+			$this->preflightResponse();
+		}
+
 		// METHOD INPUTS
 		// ------------------------------------------------------------
+		// Inputs are optional, the credentials can travel on the headers and
+		// most of the endpoints take all their parameters from the URI
 		$inputs = $this->getMethodInputs();
-		if (empty($inputs)) {
-			$this->response(400, 'Bad Request', array('message' => 'Missing method inputs.'));
-		}
 
 		// ENDPOINT PARAMETERS
 		// ------------------------------------------------------------
@@ -115,23 +129,30 @@ class pluginAPI extends Plugin
 		// Token from the plugin, the user can change it on the settings of the plugin
 		$tokenAPI = $this->getValue('token');
 
+		// The token is taken from the Authorization header and falls back to
+		// the "token" input, which is deprecated
+		$providedToken = $this->getRequestToken($inputs);
+
 		// Check empty token
-		if (empty($inputs['token'])) {
-			$this->response(400, 'Bad Request', array('message' => 'Missing API token.'));
+		if (empty($providedToken)) {
+			$this->response(401, 'Unauthorized', array('message' => 'Missing API token.'));
 		}
 
 		// Check if the token is valid
-		if ($inputs['token'] !== $tokenAPI) {
+		if (!hash_equals((string) $tokenAPI, (string) $providedToken)) {
 			$this->response(401, 'Unauthorized', array('message' => 'Invalid API token.'));
 		}
 
 		// AUTHENTICATION TOKEN
 		// ------------------------------------------------------------
+		// The token is taken from the X-Auth-Token header and falls back to
+		// the "authentication" input, which is deprecated
+		$authentication = $this->getRequestAuthentication($inputs);
 		$writePermissions = false;
-		if (!empty($inputs['authentication'])) {
+		if (!empty($authentication)) {
 
 			// Get the user with the authentication token, FALSE if it doesn't exist
-			$username = $users->getByAuthToken($inputs['authentication']);
+			$username = $users->getByAuthToken($authentication);
 			if ($username !== false) {
 				try {
 					$user = new User($username);
@@ -286,6 +307,110 @@ class pluginAPI extends Plugin
 		return true;
 	}
 
+	// Returns the value of a request header, empty string when it's not present
+	private function getRequestHeader($header)
+	{
+		$key = 'HTTP_' . strtoupper(str_replace('-', '_', $header));
+		if (!empty($_SERVER[$key])) {
+			return trim($_SERVER[$key]);
+		}
+
+		// Some CGI/FastCGI setups move the Authorization header out of the way
+		if (!empty($_SERVER['REDIRECT_' . $key])) {
+			return trim($_SERVER['REDIRECT_' . $key]);
+		}
+
+		return '';
+	}
+
+	// Returns the API token sent by the client
+	// Order: Authorization: Bearer <token>, then the deprecated "token" input
+	private function getRequestToken($inputs)
+	{
+		$authorization = $this->getRequestHeader('Authorization');
+		if (!empty($authorization)) {
+			$matches = array();
+			if (preg_match('/^Bearer\s+(.+)$/i', $authorization, $matches)) {
+				return trim($matches[1]);
+			}
+		}
+
+		if (!empty($inputs['token'])) {
+			return $inputs['token'];
+		}
+
+		return '';
+	}
+
+	// Returns the user authentication token sent by the client
+	// Order: X-Auth-Token, then the deprecated "authentication" input
+	private function getRequestAuthentication($inputs)
+	{
+		$header = $this->getRequestHeader('X-Auth-Token');
+		if (!empty($header)) {
+			return $header;
+		}
+
+		if (!empty($inputs['authentication'])) {
+			return $inputs['authentication'];
+		}
+
+		return '';
+	}
+
+	// Returns the value for the Access-Control-Allow-Origin header,
+	// FALSE when the origin of the request is not allowed
+	private function getAllowedOrigin()
+	{
+		$allowedOrigins = trim($this->getValue('allowedOrigins', false));
+
+		// Any origin is allowed
+		if (($allowedOrigins === '') || ($allowedOrigins === '*')) {
+			return '*';
+		}
+
+		$origin = $this->getRequestHeader('Origin');
+		if (empty($origin)) {
+			return false;
+		}
+
+		foreach (explode(',', $allowedOrigins) as $allowedOrigin) {
+			if (strcasecmp(trim($allowedOrigin), $origin) === 0) {
+				return $origin;
+			}
+		}
+
+		return false;
+	}
+
+	// Sends the CORS headers, when the origin is not allowed no header is sent
+	// and the browser blocks the response
+	private function sendCorsHeaders()
+	{
+		$origin = $this->getAllowedOrigin();
+		if ($origin === false) {
+			header('Vary: Origin');
+			return;
+		}
+
+		header('Access-Control-Allow-Origin: ' . $origin);
+		if ($origin !== '*') {
+			// The response changes with the origin, it must not be cached for all of them
+			header('Vary: Origin');
+		}
+	}
+
+	// Answers the CORS preflight request, the body is always empty
+	private function preflightResponse()
+	{
+		header('HTTP/1.1 204 No Content');
+		$this->sendCorsHeaders();
+		header('Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS');
+		header('Access-Control-Allow-Headers: Authorization, Content-Type, X-Auth-Token');
+		header('Access-Control-Max-Age: 86400');
+		exit();
+	}
+
 	private function getMethod()
 	{
 		// METHODS
@@ -368,7 +493,10 @@ class pluginAPI extends Plugin
 	private function response($code = 200, $message = 'OK', $data = array())
 	{
 		header('HTTP/1.1 ' . $code . ' ' . $message);
-		header('Access-Control-Allow-Origin: *');
+		$this->sendCorsHeaders();
+		if ($code === 401) {
+			header('WWW-Authenticate: Bearer realm="Bludit API"');
+		}
 		header('Content-Type: application/json');
 		$json = json_encode($data);
 		exit($json);

--- a/bl-plugins/api/plugin.php
+++ b/bl-plugins/api/plugin.php
@@ -320,6 +320,18 @@ class pluginAPI extends Plugin
 			return trim($_SERVER['REDIRECT_' . $key]);
 		}
 
+		// Apache with mod_php doesn't publish the Authorization header on $_SERVER
+		if (function_exists('apache_request_headers')) {
+			$headers = apache_request_headers();
+			if (is_array($headers)) {
+				foreach ($headers as $name => $value) {
+					if ((strcasecmp($name, $header) === 0) && ($value !== '')) {
+						return trim($value);
+					}
+				}
+			}
+		}
+
 		return '';
 	}
 
@@ -497,6 +509,9 @@ class pluginAPI extends Plugin
 		if ($code === 401) {
 			header('WWW-Authenticate: Bearer realm="Bludit API"');
 		}
+		// The responses are tied to the credentials of the request, they must
+		// never be stored by the browser or by a proxy in between
+		header('Cache-Control: no-store');
 		header('Content-Type: application/json');
 		$json = json_encode($data);
 		exit($json);


### PR DESCRIPTION
## Problem

The API token and the user authentication token could only travel as query string or body parameters:

```
GET /api/pages?token=<api-token>&authentication=<auth-token>
```

For `GET` and `DELETE` that puts the credentials in the URL, so they end up in the web server access logs, in the `Referer` header and in any proxy cache in between. There was also no way to call the API from a browser with custom headers, because the `OPTIONS` preflight was answered with `400 Bad Request`, and `Access-Control-Allow-Origin: *` was hardcoded with no way to restrict it.

## Changes

* The API token is read from `Authorization: Bearer <token>`. The `token` input keeps working as a deprecated fallback.
* The user authentication token is read from `X-Auth-Token: <token>`. The `authentication` input keeps working as a deprecated fallback.
* `OPTIONS` requests are answered with `204 No Content` and the `Access-Control-Allow-*` headers before any credential check, since a preflight never carries credentials.
* New plugin setting **Allowed origins**: a comma separated list of the origins allowed to call the API from a browser. It defaults to `*`, which is the current behaviour. When the list is restricted, the request origin is echoed back only if it matches, and `Vary: Origin` is sent so the response is not cached for every origin.
* The API token is compared with `hash_equals()`.

### Behaviour changes

* A request without an API token now returns `401 Unauthorized` with `WWW-Authenticate: Bearer realm="Bludit API"` instead of `400 Bad Request`.
* The inputs are no longer mandatory. `GET /api/pages` with the credentials only on the headers used to fail with `Missing method inputs.`.

Existing clients that send `token` and `authentication` as parameters are unaffected.

## Usage

```bash
# Read
curl -H "Authorization: Bearer <api-token>" https://example.com/api/pages

# Write
curl -X POST \
     -H "Authorization: Bearer <api-token>" \
     -H "X-Auth-Token: <auth-token>" \
     -H "Content-Type: application/json" \
     -d '{"title":"New page","content":"Hello"}' \
     https://example.com/api/pages
```

## Testing

Tested against a fresh install served with the PHP built-in server:

* `GET /api/pages?token=...` still returns `200`, no client is broken.
* `GET /api/pages` with only `Authorization: Bearer` returns the list of pages.
* `POST /api/pages` with `Authorization` + `X-Auth-Token` creates the page.
* `GET /api/pages` with no credentials returns `401` with `WWW-Authenticate`.
* `OPTIONS /api/pages` returns `204` with the allow methods and headers.
* With `Allowed origins` set to `https://example.com, https://app.example.com`, the header is echoed for those origins and omitted for any other, always with `Vary: Origin`.


---
_Generated by [Claude Code](https://claude.ai/code/session_0193cM7KXqKVx2qU6Vn79tZP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an API setting for configuring allowed browser origins.
  - Supports comma-separated origins, including the `*` wildcard.
  - Added support for API credentials supplied through standard authentication headers.
  - API responses now include appropriate CORS and cache-control headers.
  - Added clearer authentication failure responses for unauthorized requests.

- **Documentation**
  - Added English labels and explanatory guidance for the allowed-origins setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->