### PR TITLE
API: require write permissions to read users, stop exposing server paths

### DIFF
--- a/bl-plugins/api/plugin.php
+++ b/bl-plugins/api/plugin.php
@@ -248,11 +248,11 @@ class pluginAPI extends Plugin
 			$data = $this->deleteCategory($categoryKey);
 		}
 		// (GET) /api/users
-		elseif (($method === 'GET') && ($parameters[0] === 'users') && empty($parameters[1])) {
+		elseif (($method === 'GET') && ($parameters[0] === 'users') && empty($parameters[1]) && $writePermissions) {
 			$data = $this->getUsers();
 		}
 		// (GET) /api/users/<username>
-		elseif (($method === 'GET') && ($parameters[0] === 'users') && !empty($parameters[1])) {
+		elseif (($method === 'GET') && ($parameters[0] === 'users') && !empty($parameters[1]) && $writePermissions) {
 			$username = $parameters[1];
 			$data = $this->getUser($username);
 		}
@@ -1315,6 +1315,8 @@ class pluginAPI extends Plugin
 
 	/*
 	 | Returns all files uploaded for a specific page, includes any type of file.
+	 | The files are described by their public URL, the filesystem path of the
+	 | server is never returned.
 	 |
 	 | @return	array
          */
@@ -1323,20 +1325,21 @@ class pluginAPI extends Plugin
 		$chunk = false;
 		$sortByDate = true;
 		$path = PATH_UPLOADS_PAGES . $pageKey . DS;
+		$endpoint = DOMAIN_UPLOADS_PAGES . $pageKey . '/';
 		$listFiles = Filesystem::listFiles($path, '*', '*', $sortByDate, $chunk);
 
 		$files = array();
 		foreach ($listFiles as $file) {
 			$info = array('thumbnail' => '');
-			$info['file'] = $file;
 			$info['filename'] = basename($file);
+			$info['url'] = $endpoint . $info['filename'];
 			$info['mime'] = Filesystem::mimeType($file);
 			$info['size'] = Filesystem::getSize($file);
 
 			// Check if thumbnail exists for the file
 			$thumbnail = $path . 'thumbnails' . DS . $info['filename'];
 			if (Filesystem::fileExists($thumbnail)) {
-				$info['thumbnail'] = $thumbnail;
+				$info['thumbnail'] = $endpoint . 'thumbnails/' . $info['filename'];
 			}
 
 			array_push($files, $info);
@@ -1407,7 +1410,7 @@ class pluginAPI extends Plugin
 				'status' => '0',
 				'message' => 'File uploaded.',
 				'filename' => $filename,
-				'absolutePath' => $absolutePath,
+				'url' => $absoluteURL,
 				'absoluteURL' => $absoluteURL
 			);
 		}

--- a/bl-plugins/api/plugin.php
+++ b/bl-plugins/api/plugin.php
@@ -1332,14 +1332,17 @@ class pluginAPI extends Plugin
 		foreach ($listFiles as $file) {
 			$info = array('thumbnail' => '');
 			$info['filename'] = basename($file);
-			$info['url'] = $endpoint . $info['filename'];
+			// The listing returns the files on disk, they can be uploaded by FTP
+			// and carry characters such as # or ? that break the URL
+			$encodedFilename = rawurlencode($info['filename']);
+			$info['url'] = $endpoint . $encodedFilename;
 			$info['mime'] = Filesystem::mimeType($file);
 			$info['size'] = Filesystem::getSize($file);
 
 			// Check if thumbnail exists for the file
 			$thumbnail = $path . 'thumbnails' . DS . $info['filename'];
 			if (Filesystem::fileExists($thumbnail)) {
-				$info['thumbnail'] = $endpoint . 'thumbnails/' . $info['filename'];
+				$info['thumbnail'] = $endpoint . 'thumbnails/' . $encodedFilename;
 			}
 
 			array_push($files, $info);
@@ -1410,7 +1413,9 @@ class pluginAPI extends Plugin
 				'status' => '0',
 				'message' => 'File uploaded.',
 				'filename' => $filename,
-				'url' => $absoluteURL,
+				// Same shape as the files listing, the deprecated absoluteURL is
+				// left as it was so the current clients don't change
+				'url' => DOMAIN_UPLOADS_PAGES . $pageKey . '/' . rawurlencode($filename),
 				'absoluteURL' => $absoluteURL
 			);
 		}


### PR DESCRIPTION
## Problem

Two pieces of information were reachable with the read only API token, which is a single site wide token meant to be embedded in front-ends:

1. **`GET /api/users` returned the full profile of every user in the site**, and `GET /api/users/<username>` any single one. Every other user operation (create, edit, delete) already required the authentication token of an admin, only the reads were open.
2. **The files endpoints returned absolute filesystem paths of the server.** The listing returned `file` and `thumbnail` as paths like `/var/www/bludit/bl-content/uploads/pages/<key>/photo.jpg`, and an upload answered with `absolutePath`. That discloses the installation directory and the server layout to any API client.

## Changes

* `GET /api/users` and `GET /api/users/<username>` now require the authentication token, consistent with the write operations on the same resource. Without it they answer `401` with `Access denied or invalid endpoint.`, the same as the other protected endpoints.
* `GET /api/files/<page-key>` describes each file by its public URL: `file` (a path) is replaced by `url`, and `thumbnail` is a URL instead of a path.
* `POST /api/files/<page-key>` no longer returns `absolutePath`, and gains `url`. `absoluteURL` is kept so existing clients are not broken.

### Breaking changes

Clients reading users with only the API token have to send the authentication token of an admin. Clients reading `file` or `thumbnail` from the files listing have to read `url` and `thumbnail`, which are now URLs.

## Testing

Tested against a fresh install served with the PHP built-in server:

* `GET /api/users?token=...` and `GET /api/users/admin?token=...` return `401`.
* The same requests with `&authentication=...` return the profiles.
* `POST /api/files/<page-key>` returns `filename`, `url` and `absoluteURL`, with no filesystem path.
* `GET /api/files/<page-key>` returns `filename`, `url`, `mime`, `size` and `thumbnail`, with no filesystem path.


---
_Generated by [Claude Code](https://claude.ai/code/session_0193cM7KXqKVx2qU6Vn79tZP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Restricted user listing and individual user retrieval to authenticated administrators with write permissions.

* **Bug Fixes**
  * File listings and upload responses no longer expose server filesystem paths.
  * File and thumbnail links now use public URLs.
  * Filenames are URL-encoded so special characters such as `#` and `?` work correctly in links.
  * Upload responses continue to include the deprecated absolute URL field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->