### PR TITLE
Expose the complete page schema on Page::json()

### DIFF
--- a/bl-kernel/pages.class.php
+++ b/bl-kernel/pages.class.php
@@ -70,6 +70,10 @@ class Pages extends dbJSON
 					global $site;
 					$customFields = $site->customFields();
 					foreach ($args['custom'] as $customField => $customValue) {
+						// Ignore the fields not defined on the settings of the site
+						if (!isset($customFields[$customField]['type'])) {
+							continue;
+						}
 						$html = Sanitize::html($customValue);
 						// Store the custom field as defined type
 						settype($html, $customFields[$customField]['type']);
@@ -190,6 +194,10 @@ class Pages extends dbJSON
 					global $site;
 					$customFields = $site->customFields();
 					foreach ($args['custom'] as $customField => $customValue) {
+						// Ignore the fields not defined on the settings of the site
+						if (!isset($customFields[$customField]['type'])) {
+							continue;
+						}
 						$html = Sanitize::html($customValue);
 						// Store the custom field as defined type
 						settype($html, $customFields[$customField]['type']);

--- a/bl-kernel/pages.class.php
+++ b/bl-kernel/pages.class.php
@@ -82,6 +82,8 @@ class Pages extends dbJSON
 					unset($args['custom']);
 					continue;
 				}
+				// The page does not have custom fields
+				$finalValue = $value;
 			} elseif (isset($args[$field])) {
 				// Sanitize if will be stored on database
 				$finalValue = Sanitize::html($args[$field]);
@@ -206,6 +208,8 @@ class Pages extends dbJSON
 					unset($args['custom']);
 					continue;
 				}
+				// The custom fields are not sent, keep the current ones
+				$finalValue = isset($this->db[$key][$field]) ? $this->db[$key][$field] : $value;
 			} elseif (isset($args[$field])) {
 				// Sanitize if will be stored on database
 				$finalValue = Sanitize::html($args[$field]);

--- a/bl-kernel/pagex.class.php
+++ b/bl-kernel/pagex.class.php
@@ -290,9 +290,20 @@ class Page
 		$tmp['category'] 	= $this->category();
 		$tmp['uuid'] 		= $this->uuid();
 		$tmp['dateUTC']		= Date::convertToUTC($this->dateRaw(), DB_DATE_FORMAT, DB_DATE_FORMAT);
+		$tmp['dateModified'] 	= $this->dateModified();
+		$tmp['dateModifiedRaw'] = $this->getValue('dateModified');
 		$tmp['permalink'] 	= $this->permalink(true);
 		$tmp['coverImage'] 		= $this->coverImage(true);
 		$tmp['coverImageFilename'] 	= $this->coverImage(false);
+		$tmp['template'] 	= $this->template();
+		$tmp['position'] 	= $this->position();
+		$tmp['allowComments'] 	= $this->allowComments();
+		$tmp['noindex'] 	= $this->noindex();
+		$tmp['nofollow'] 	= $this->nofollow();
+		$tmp['noarchive'] 	= $this->noarchive();
+		$tmp['parent'] 		= $this->parentKey();
+		$tmp['children'] 	= $this->childrenKeys();
+		$tmp['custom'] 		= $this->customFields();
 
 		if ($returnsArray) {
 			return $tmp;
@@ -603,6 +614,22 @@ class Page
 			return $this->vars['custom'][$field]['value'];
 		}
 		return false;
+	}
+
+	// Returns an array with all the custom fields of the page, field => value
+	// Returns an empty array if the page doesn't have custom fields
+	public function customFields()
+	{
+		$custom = $this->getValue('custom');
+		if (!is_array($custom)) {
+			return array();
+		}
+
+		$fields = array();
+		foreach ($custom as $field => $options) {
+			$fields[$field] = isset($options['value']) ? $options['value'] : $options;
+		}
+		return $fields;
 	}
 
 	// Returns an array with all pages key related to the page

--- a/bl-kernel/pagex.class.php
+++ b/bl-kernel/pagex.class.php
@@ -627,7 +627,11 @@ class Page
 
 		$fields = array();
 		foreach ($custom as $field => $options) {
-			$fields[$field] = isset($options['value']) ? $options['value'] : $options;
+			// Ignore the fields not stored with the expected structure
+			if (!is_array($options) || !array_key_exists('value', $options)) {
+				continue;
+			}
+			$fields[$field] = $options['value'];
 		}
 		return $fields;
 	}


### PR DESCRIPTION
## Problem

`Page::json()` returned 17 fields, but a page stores more than that (`Pages::$dbFields`). Everything that consumes the JSON representation of a page, the API included, was blind to:

* **`custom`**, the custom fields, which are the closest thing Bludit has to structured content and were impossible to read from the API.
* `template`, `position`, `dateModified`, `allowComments`, `noindex`, `nofollow`, `noarchive`.
* The hierarchy: neither the parent nor the children of a page were visible.

## Changes

* `Page::json()` now also returns `custom`, `template`, `position`, `dateModified`, `dateModifiedRaw`, `allowComments`, `noindex`, `nofollow`, `noarchive`, `parent` and `children`.
* New method `Page::customFields()`, returns the custom fields of the page as a flat map `field => value`, an empty array when the page has none.
* `Pages::add()` and `Pages::edit()` ignore the custom fields that are not defined on the settings of the site. Before this change, writing a page with a custom field that is not defined ended on an undefined array key error, which is easy to hit now that a client can read `custom` and send it back.

The change is additive, every existing field keeps its name and its value, so themes and the admin content list are unaffected.

### Example

```json
{
    "key": "header-auth-page/real-child",
    "title": "Child page",
    "dateModified": "August 30, 2026",
    "dateModifiedRaw": "2026-08-30 16:35:11",
    "template": "",
    "position": 0,
    "allowComments": true,
    "noindex": false,
    "nofollow": false,
    "noarchive": false,
    "parent": "header-auth-page",
    "children": [],
    "custom": {
        "subtitle": "A subtitle",
        "featured": true
    }
}
```

Note that `custom` follows the semantics of `Pages::edit()`: sending `custom` on an edit replaces the whole object, so a client that wants to keep the other custom fields has to send them back.

## Testing

Tested against a fresh install served with the PHP built-in server, with `subtitle` (string) and `featured` (boolean) defined as custom fields:

* `POST /api/pages` with `custom` stores the fields with their defined type and returns them, and a custom field not defined on the settings is ignored instead of raising an error.
* `PUT /api/pages/<key>` with `custom` updates the value, `dateModified` reflects the edit.
* Creating a page with `parent` returns `parent` on the child and the child key on the `children` of the parent.
* The site and the admin content list, which also consumes `Page::json()`, render with no errors.


---
_Generated by [Claude Code](https://claude.ai/code/session_0193cM7KXqKVx2qU6Vn79tZP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Page data exports now include additional metadata, hierarchy details, publishing settings, and custom fields.
  - Added support for retrieving all custom field values associated with a page.

- **Bug Fixes**
  - Undefined custom fields are no longer saved when creating or editing pages.
  - Existing custom field values are preserved when editing a page without submitting new custom fields.
  - Default custom field values are applied when creating a page without submitted custom fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->